### PR TITLE
Combine metric syncer and updater in one structure

### DIFF
--- a/cmd/csv_receiver/csv_receiver.go
+++ b/cmd/csv_receiver/csv_receiver.go
@@ -1,4 +1,4 @@
-package csv_receiver
+package main
 
 import (
 	"encoding/csv"
@@ -13,6 +13,7 @@ import (
 
 type CSVReceiver struct {
 	FullPath string
+	sinks.SyncMetricHandler
 }
 
 /*
@@ -22,7 +23,7 @@ type CSVReceiver struct {
 *       - Metric2.csv
  */
 
-func (r *CSVReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *string) error {
+func (r CSVReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *string) error {
 	if len(msg.DBName) == 0 {
 		return errors.New("Empty Database")
 	}

--- a/cmd/csv_receiver/main.go
+++ b/cmd/csv_receiver/main.go
@@ -1,4 +1,4 @@
-package csv_receiver
+package main
 
 import (
 	"flag"
@@ -23,13 +23,11 @@ func main() {
 	}
 
 	var server sinks.Receiver
-	syncHandler := new(sinks.SyncMetricHandler)
 
+	server = CSVReceiver{FullPath: *StorageFolder, SyncMetricHandler: sinks.NewSyncMetricHandler(1024)}
 	log.Println("[INFO]: CSV Receiver Intialized")
-	server = &CSVReceiver{FullPath: *StorageFolder}
 
-	rpc.RegisterName("Receiver", server)     // Primary Receiver
-	rpc.RegisterName("Handler", syncHandler) // Sync Metric Handler
+	rpc.RegisterName("Receiver", server) // Primary Receiver
 	log.Println("[INFO]: Registered Receiver")
 	rpc.HandleHTTP()
 

--- a/cmd/kafka_prod_receiver/main.go
+++ b/cmd/kafka_prod_receiver/main.go
@@ -1,4 +1,4 @@
-package kafka_prod_receiver
+package main
 
 import (
 	"flag"
@@ -24,15 +24,12 @@ func main() {
 	}
 
 	var server sinks.Receiver
-	syncHandler := new(sinks.SyncMetricHandler)
-
-	server, err := NewKafkaProducer()
+	server, err := NewKafkaProducer("localhost", *port, "pgwatch3", 0)
 	if err != nil {
 		log.Println("[ERROR]: Unable to create Kafka Producer ", err)
 	}
 
-	rpc.RegisterName("Receiver", server)     // Primary Receiver
-	rpc.RegisterName("Handler", syncHandler) // Sync Metric Handler
+	rpc.RegisterName("Receiver", server) // Primary Receiver
 	log.Println("[INFO]: Registered Receiver")
 	rpc.HandleHTTP()
 

--- a/cmd/parquet_receiver/main.go
+++ b/cmd/parquet_receiver/main.go
@@ -1,4 +1,4 @@
-package parquet_receiver
+package main
 
 import (
 	"flag"
@@ -24,12 +24,9 @@ func main() {
 	}
 
 	var server sinks.Receiver
-	syncHandler := new(sinks.SyncMetricHandler)
+	server = &ParqReceiver{FullPath: *StorageFolder, SyncMetricHandler: sinks.NewSyncMetricHandler(1024)}
 
-	server = &ParqReceiver{FullPath: *StorageFolder}
-
-	rpc.RegisterName("Receiver", server)     // Primary Receiver
-	rpc.RegisterName("Handler", syncHandler) // Sync Metric Handler
+	rpc.RegisterName("Receiver", server) // Primary Receiver
 	log.Println("[INFO]: Registered Receiver")
 	rpc.HandleHTTP()
 

--- a/cmd/parquet_receiver/parquet_receiver.go
+++ b/cmd/parquet_receiver/parquet_receiver.go
@@ -1,4 +1,4 @@
-package parquet_receiver
+package main
 
 import (
 	"errors"
@@ -13,6 +13,7 @@ import (
 
 type ParqReceiver struct {
 	FullPath string
+	sinks.SyncMetricHandler
 }
 
 type ParquetSchema struct {
@@ -25,7 +26,7 @@ type ParquetSchema struct {
 	SysIdentifier     string
 }
 
-func (r *ParqReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *string) error {
+func (r ParqReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *string) error {
 
 	if len(msg.DBName) == 0 {
 		*logMsg = "False Record delieverd"

--- a/cmd/text_receiver/main.go
+++ b/cmd/text_receiver/main.go
@@ -1,4 +1,4 @@
-package text_receiver
+package main
 
 import (
 	"flag"
@@ -24,12 +24,9 @@ func main() {
 	}
 
 	var server sinks.Receiver
-	syncHandler := new(sinks.SyncMetricHandler)
+	server = TextReceiver{FullPath: *StorageFolder, SyncMetricHandler: sinks.NewSyncMetricHandler(1024)}
 
-	server = &TextReceiver{FullPath: *StorageFolder}
-
-	rpc.RegisterName("Receiver", server)     // Primary Receiver
-	rpc.RegisterName("Handler", syncHandler) // Sync Metric Handler
+	rpc.RegisterName("Receiver", server) // Primary Receiver
 	log.Println("[INFO]: Registered Receiver")
 	rpc.HandleHTTP()
 

--- a/cmd/text_receiver/text_receiver.go
+++ b/cmd/text_receiver/text_receiver.go
@@ -1,4 +1,4 @@
-package text_receiver
+package main
 
 import (
 	"bufio"
@@ -13,9 +13,10 @@ import (
 
 type TextReceiver struct {
 	FullPath string
+	sinks.SyncMetricHandler
 }
 
-func (r *TextReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *string) error {
+func (r TextReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *string) error {
 
 	// Write Metrics in a text file
 	fileName := fmt.Sprint(msg.CustomTags["pgwatchId"]) + ".txt"

--- a/sinks/common.go
+++ b/sinks/common.go
@@ -2,7 +2,6 @@ package sinks
 
 import (
 	"encoding/json"
-	"errors"
 	"log"
 
 	"github.com/cybertec-postgresql/pgwatch/v3/api"
@@ -14,28 +13,4 @@ func GetJson[K map[string]string | map[string]any | float64 | api.MeasurementEnv
 		log.Default().Fatal("[ERROR]: Unable to parse Metric Definition")
 	}
 	return string(jsonString)
-}
-
-func (handler *SyncMetricHandler) SyncMetricHandler(syncReq *api.RPCSyncRequest, logMsg *string) error {
-	if len(syncReq.Operation) == 0 {
-		return errors.New("Empty Operation.")
-	}
-	if len(syncReq.DbName) == 0 {
-		return errors.New("Empty Database.")
-	}
-	if len(syncReq.MetricName) == 0 {
-		return errors.New("Empty Metric Provided.")
-	}
-
-	go handler.PopulateChannel(syncReq)
-	return nil
-}
-
-func (handler *SyncMetricHandler) PopulateChannel(syncReq *api.RPCSyncRequest) {
-	handler.SyncChannel <- *syncReq
-}
-
-func (handler *SyncMetricHandler) GetSyncChannelContent() api.RPCSyncRequest {
-	content := <-handler.SyncChannel
-	return content
 }

--- a/sinks/types.go
+++ b/sinks/types.go
@@ -1,13 +1,48 @@
 package sinks
 
 import (
+	"errors"
+	"time"
+
 	"github.com/cybertec-postgresql/pgwatch/v3/api"
 )
 
 type Receiver interface {
 	UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *string) error
+	SyncMetric(syncReq *api.RPCSyncRequest, logMsg *string) error
 }
 
 type SyncMetricHandler struct {
 	SyncChannel chan api.RPCSyncRequest
+}
+
+func NewSyncMetricHandler(chanSize int) SyncMetricHandler {
+	if chanSize == 0 {
+		chanSize = 1024
+	}
+	return SyncMetricHandler{SyncChannel: make(chan api.RPCSyncRequest, chanSize)}
+}
+
+func (handler SyncMetricHandler) SyncMetric(syncReq *api.RPCSyncRequest, logMsg *string) error {
+	if len(syncReq.Operation) == 0 {
+		return errors.New("Empty Operation.")
+	}
+	if len(syncReq.DbName) == 0 {
+		return errors.New("Empty Database.")
+	}
+	if len(syncReq.MetricName) == 0 {
+		return errors.New("Empty Metric Provided.")
+	}
+
+	select {
+	case handler.SyncChannel <- *syncReq:
+		return nil
+	case <-time.After(5 * time.Second):
+		return errors.New("Timeout while trying to sync metric")
+	}
+}
+
+func (handler SyncMetricHandler) GetSyncChannelContent() api.RPCSyncRequest {
+	content := <-handler.SyncChannel
+	return content
 }


### PR DESCRIPTION
Fix all cmd packages names to `main`. Include SyncMetricHandler into receiver structs. Use buffered channel for sync requests instead of goroutines. 

Fixes all errors produced by #17 