### PR TITLE
Fix typo in flag description

### DIFF
--- a/cmd/clickhouse_receiver/main.go
+++ b/cmd/clickhouse_receiver/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 
 	// Important Flags
-	port := flag.String("port", "-1", "Specify the port where you want you sink to receive the measaurements on.")
+	port := flag.String("port", "-1", "Specify the port where you want your sink to receive the measurements on.")
 	flag.Parse()
 
 	if *port == "-1" {

--- a/cmd/csv_receiver/main.go
+++ b/cmd/csv_receiver/main.go
@@ -13,7 +13,7 @@ import (
 func main() {
 
 	// Important Flags
-	port := flag.String("port", "-1", "Specify the port where you want you sink to receive the measaurements on.")
+	port := flag.String("port", "-1", "Specify the port where you want your sink to receive the measurements on.")
 	StorageFolder := flag.String("rootFolder", ".", "Only for formats like CSV...\n")
 	flag.Parse()
 

--- a/cmd/kafka_prod_receiver/main.go
+++ b/cmd/kafka_prod_receiver/main.go
@@ -13,7 +13,7 @@ import (
 func main() {
 
 	// Important Flags
-	port := flag.String("port", "-1", "Specify the port where you want you sink to receive the measaurements on.")
+	port := flag.String("port", "-1", "Specify the port where you want your sink to receive the measurements on.")
 	kafkaHost := flag.String("kafkaHost", "localhost:9092", "Specify the host and port of the kafka instance")
 	autoadd := flag.Bool("autoadd", true, "Specifies if new databases are automatically added as a new kafka topic. Default is true. You can disable this service and send an 'ADD' sync metric signal before sending data")
 	flag.Parse()

--- a/cmd/llama_receiver/main.go
+++ b/cmd/llama_receiver/main.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	// Important Flags
 	// receiverType := flag.String("type", "", "The type of sink that you want to keep this node as.\nAvailable options:\n\t- csv\n\t- text\n\t- parquet")
-	port := flag.String("port", "-1", "Specify the port where you want you sink to receive the measaurements on.")
+	port := flag.String("port", "-1", "Specify the port where you want your sink to receive the measurements on.")
 	serverURI := flag.String("ollamaURI", "http://localhost:11434", "URI for Ollama server")
 	pgURI := flag.String("pgURI", "postgres://pgwatch:pgwatchadmin@localhost:5432/postgres", "connection string for postgres")
 	batchSize := flag.Int("batchSize", 10, "Specify batch size for generating LLM insights")

--- a/cmd/s3_receiver/main.go
+++ b/cmd/s3_receiver/main.go
@@ -15,7 +15,7 @@ func main() {
 
 	// Important Flags
 	// receiverType := flag.String("type", "", "The type of sink that you want to keep this node as.\nAvailable options:\n\t- csv\n\t- text\n\t- parquet")
-	port := flag.String("port", "-1", "Specify the port where you want you sink to receive the measaurements on.")
+	port := flag.String("port", "-1", "Specify the port where you want your sink to receive the measurements on.")
 	awsEndpoint := flag.String("awsEndpoint", "", "Specify aws endpoint")
 	awsRegion := flag.String("awsRegion", "us-east-1", "Specify AWS region")
 	username := os.Getenv("awsuser")

--- a/cmd/text_receiver/main.go
+++ b/cmd/text_receiver/main.go
@@ -14,7 +14,7 @@ func main() {
 
 	// Important Flags
 	// receiverType := flag.String("type", "", "The type of sink that you want to keep this node as.\nAvailable options:\n\t- csv\n\t- text\n\t- parquet")
-	port := flag.String("port", "-1", "Specify the port where you want you sink to receive the measaurements on.")
+	port := flag.String("port", "-1", "Specify the port where you want your sink to receive the measurements on.")
 	StorageFolder := flag.String("rootFolder", ".", "Only for formats like CSV...\n")
 	flag.Parse()
 


### PR DESCRIPTION
### Title
Fix typos in sink CLI flag description

### Description:
While reading the code for GSoC-25 preparation, I found two typos in the sink CLI flag that exists in the main.go file for all receivers

### Before (Old)
```port := flag.String("port", "-1", "Specify the port where you want you sink to receive the measaurements on.")```

### After (Fixed)
```port := flag.String("port", "-1", "Specify the port where you want your sink to receive the measurements on.")```

### Change
"you" => "your"
"measaurements" => "measurements"