### PR TITLE
fix: prevent SQL injection in table creation by sanitizing table name

### DIFF
--- a/cmd/duckdb_receiver/duckdb_receiver.go
+++ b/cmd/duckdb_receiver/duckdb_receiver.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"log"
 	"time"
+	"regexp"
 
 	"github.com/cybertec-postgresql/pgwatch/v3/api"
 	"github.com/destrex271/pgwatch3_rpc_server/sinks"
@@ -21,6 +22,12 @@ type DuckDBReceiver struct {
 }
 
 func (dbr *DuckDBReceiver) initializeTable() {
+	// Allow only alphanumeric and underscores in table names
+	validateTableName := regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
+	if !validateTableName.MatchString(dbr.TableName) {
+		log.Fatal("Invalid table name: potential SQL injection risk")
+	}
+
 	createTableQuery := "CREATE TABLE IF NOT EXISTS " + dbr.TableName + "(dbname VARCHAR, metric_name VARCHAR, data JSON, custom_tags JSON, metric_def JSON, timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (dbname, timestamp))"
 	_, err := dbr.Conn.Exec(createTableQuery)
 	if err != nil {


### PR DESCRIPTION
### Description
the recently added `duckdb_receiver` didn't sanitize against Sql Injection in the `initializeTable()` method which creates the table to log the data 
`createTableQuery := "CREATE TABLE IF NOT EXISTS " + dbr.TableName + "(dbname VARCHAR, metric_name VARCHAR, data JSON, custom_tags JSON, metric_def JSON, timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (dbname, timestamp))"` 
as DuckDB allows for executeing multiple SQL statements separated by semicolons ; and supports comments through `--`
a payload as:
`tmp_name (dbname VARCHAR); DROP TABLE ...(malicious sql) -- comment the end`  being sent as the table name
would allow malicious manipulation for the database

so if an attacker somehow was able to call the RPC sink on the user behalf through RCE or misconfigured permissions he could manipulate all tables in the database

### Changes
- added regex sanitizer in `initializeTable()` to ensure only alphanumeric chars and underscores _ are present in the table name 