### PR TITLE
Fix: Validate and parse port number correctly

### DIFF
--- a/cmd/clickhouse_receiver/main.go
+++ b/cmd/clickhouse_receiver/main.go
@@ -40,7 +40,7 @@ func main() {
 	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)
 
 	if err != nil {
-		log.Println(err)
+		log.Fatal(err)
 	}
 
 	http.Serve(listener, nil)

--- a/cmd/csv_receiver/main.go
+++ b/cmd/csv_receiver/main.go
@@ -34,7 +34,7 @@ func main() {
 	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)
 
 	if err != nil {
-		log.Println(err)
+		log.Fatal(err)
 	}
 
 	http.Serve(listener, nil)

--- a/cmd/duckdb_receiver/main.go
+++ b/cmd/duckdb_receiver/main.go
@@ -35,7 +35,7 @@ func main() {
 	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)
 
 	if err != nil {
-		log.Println(err)
+		log.Fatal(err)
 	}
 
 	http.Serve(listener, nil)

--- a/cmd/kafka_prod_receiver/main.go
+++ b/cmd/kafka_prod_receiver/main.go
@@ -36,7 +36,7 @@ func main() {
 	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)
 
 	if err != nil {
-		log.Println(err)
+		log.Fatal(err)
 	}
 
 	http.Serve(listener, nil)

--- a/cmd/llama_receiver/main.go
+++ b/cmd/llama_receiver/main.go
@@ -41,7 +41,7 @@ func main() {
 	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)
 
 	if err != nil {
-		log.Println(err)
+		log.Fatal(err)
 	}
 
 	if *enableAPI {

--- a/cmd/s3_receiver/main.go
+++ b/cmd/s3_receiver/main.go
@@ -40,7 +40,7 @@ func main() {
 	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)
 
 	if err != nil {
-		log.Println(err)
+		log.Fatal(err)
 	}
 
 	http.Serve(listener, nil)

--- a/cmd/text_receiver/main.go
+++ b/cmd/text_receiver/main.go
@@ -21,7 +21,7 @@ func main() {
 	if *port == "-1" {
 		log.Println("[ERROR]: No Port Specified")
 		return
-	}
+	}	
 
 	var server sinks.Receiver
 	server = TextReceiver{FullPath: *StorageFolder, SyncMetricHandler: sinks.NewSyncMetricHandler(1024)}
@@ -33,7 +33,7 @@ func main() {
 	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)
 
 	if err != nil {
-		log.Println(err)
+		log.Fatal(err)
 	}
 
 	http.Serve(listener, nil)


### PR DESCRIPTION
### problem
in all receivers the port number flag is not validated correctly 
running `go run ./cmd/[any-receiver] --port string` or `go run ./cmd/[any-receiver] --port 65536` or any invalid port number will result in crash without helpful error message
![error_message](https://github.com/user-attachments/assets/9f41412c-2ca6-4312-9208-3e129c783b50)

### fix
used strconv.Atoi to ensure the passed port is valid number in the [0-65535] range and on error print understandable error message
```
portInt, err2 := strconv.Atoi(*port)
if err2 != nil || portInt < 0 || portInt > 65535 {
    log.Println("[ERROR]: Invalid Port Number")
    return
}
``` 
although i preferred to keep 
`port := flag.String("port", "-1", "Specify the port where you want your sink to receive the measurements on.")`
as is and not use `flag.Int` and instead used strconv.Atoi 
to not reconvert it to string again when calling the listener
`listener, err := net.Listen("tcp", "0.0.0.0:"+*port)`
but if you think this is better let me know


----
i had some commit errors with the previous PR so i closed it and made a new clean one sorry for that