### PR TITLE
Implement main.go file in the parquet receiver

### DIFF
--- a/cmd/parquet_receiver/main.go
+++ b/cmd/parquet_receiver/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net"
+	"net/http"
+	"net/rpc"
+
+	"github.com/destrex271/pgwatch3_rpc_server/sinks"
+)
+
+func main() {
+	port := flag.String("port", "-1", "Specify the port where you want your sink to receive the measurements on.")
+	StorageFolder := flag.String("rootFolder", ".", "Only for formats like CSV...\n")
+
+	flag.Parse()
+
+	if *port == "-1" {
+		log.Println("[ERROR]: No Port Specified")
+		return
+	}
+
+	var server sinks.Receiver
+	server = ParqReceiver{FullPath: *StorageFolder, SyncMetricHandler: sinks.NewSyncMetricHandler(1024)}
+
+	rpc.RegisterName("Receiver", server)
+	log.Println("[INFO]: Registered Receiver")
+	rpc.HandleHTTP()
+
+	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)
+	
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	http.Serve(listener, nil)
+}


### PR DESCRIPTION
The parquet receiver only has 
`parquet_receiver.go  parquet_receiver_test.go  README.md` files
there is no main.go and on running it gives error 
```
$ go run ./cmd/parquet_receiver -port=8080 -rootFolder=.
# github.com/destrex271/pgwatch3_rpc_server/cmd/parquet_receiver
runtime.main_main·f: function main is undeclared in the main package
```

### changes
i have implemented the main.go file