### PR TITLE
Add Token-Based Authentication to RPC UpdateMeasurements Method.

### DIFF
--- a/cmd/clickhouse_receiver/env.example.sh
+++ b/cmd/clickhouse_receiver/env.example.sh
@@ -1,0 +1,5 @@
+export AUTH_TOKEN="secretKey"
+export user="DBuser"
+export password="password"
+export dbname="DBname"
+export server="localhost: portNumber"

--- a/cmd/csv_receiver/env.example.sh
+++ b/cmd/csv_receiver/env.example.sh
@@ -1,0 +1,4 @@
+export AUTH_TOKEN="secretKey"
+export rootFolder=" "
+
+//rootFolder === "directory where CSVs are written"

--- a/cmd/duckdb_receiver/env.example.sh
+++ b/cmd/duckdb_receiver/env.example.sh
@@ -1,0 +1,9 @@
+export AUTH_TOKEN="secretKey"
+
+
+
+export dbPath=" "
+export tableName=" "
+
+//dbPath === path where the DuckDB database file will be stored.
+//tableName === name of the table inside the DuckDB database where all data will be inserted.

--- a/cmd/kafka_prod_receiver/env.example.sh
+++ b/cmd/kafka_prod_receiver/env.example.sh
@@ -1,0 +1,5 @@
+export AUTH_TOKEN="secretKey"
+
+export kafkaHost="localhost: port where Kafka server is running"
+export topicPrefix="pgwatch"
+

--- a/cmd/kafka_prod_receiver/main.go
+++ b/cmd/kafka_prod_receiver/main.go
@@ -23,7 +23,7 @@ func main() {
 		return
 	}
 
-	var server sinks.Receiver
+	// var server sinks.Receiver
 	server, err := NewKafkaProducer(*kafkaHost, nil, nil, *autoadd)
 	if err != nil {
 		log.Println("[ERROR]: Unable to create Kafka Producer ", err)


### PR DESCRIPTION
I created a new wrapper structure named AuthenticatedEnvelope and modified the UpdateMeasurements method in the following .go source file.

1.ClickHouseReceiver
2.CSVReceiver
3.DuckDBReceiver
4.KafkaProdReceiver