### PR TITLE
Modify the HandleSyncMetric() function in all sinks to listen repeatedly

### DIFF
--- a/cmd/clickhouse_receiver/clickhouse_receiver.go
+++ b/cmd/clickhouse_receiver/clickhouse_receiver.go
@@ -183,8 +183,3 @@ func (r *ClickHouseReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, lo
 	*logMsg = "[INFO]: Successfully inserted batch!"
 	return nil
 }
-
-func (r *ClickHouseReceiver) HandleSyncMetric() {
-	req := <-r.SyncChannel
-	log.Println("[INFO]: handle Sync Request", req)
-}

--- a/cmd/csv_receiver/csv_receiver.go
+++ b/cmd/csv_receiver/csv_receiver.go
@@ -89,8 +89,3 @@ func (r CSVReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *st
 
 	return nil
 }
-
-func (r CSVReceiver) HandleSyncMetric() {
-	req := <-r.SyncChannel
-	log.Println("[INFO]: handled Sync Request", req)
-}

--- a/cmd/duckdb_receiver/duckdb_receiver.go
+++ b/cmd/duckdb_receiver/duckdb_receiver.go
@@ -138,8 +138,3 @@ func (r *DuckDBReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg
 	*logMsg = "[INFO]: Successfully inserted batch!"
 	return nil
 }
-
-func (r *DuckDBReceiver) HandleSyncMetric() {
-	req := <-r.SyncChannel
-	log.Println("[INFO]: handle Sync Request", req)
-}

--- a/cmd/kafka_prod_receiver/kafka_prod_receiver.go
+++ b/cmd/kafka_prod_receiver/kafka_prod_receiver.go
@@ -20,12 +20,19 @@ type KafkaProdReceiver struct {
 
 // Handle Sync Metric Instructions
 func (r *KafkaProdReceiver) HandleSyncMetric() {
-	req := <-r.SyncChannel
-	switch req.Operation {
-	case "DELETE":
-		r.CloseConnectionForDB(req.DbName)
-	case "ADD":
-		r.AddTopicIfNotExists(req.DbName)
+	for {
+		req, ok := r.GetSyncChannelContent()
+		if !ok {
+			// channel has been closed
+			return
+		}
+
+		switch req.Operation {
+		case "DELETE":
+			r.CloseConnectionForDB(req.DbName)
+		case "ADD":
+			r.AddTopicIfNotExists(req.DbName)
+		}
 	}
 }
 

--- a/cmd/parquet_receiver/parquet_receiver.go
+++ b/cmd/parquet_receiver/parquet_receiver.go
@@ -27,10 +27,14 @@ type ParquetSchema struct {
 }
 
 func NewParquetReceiver(fullPath string) *ParquetReceiver {
-	return &ParquetReceiver{
+	pr := &ParquetReceiver{
 		FullPath:          fullPath,
 		SyncMetricHandler: sinks.NewSyncMetricHandler(1024),
 	}
+
+	go pr.HandleSyncMetric()
+
+	return pr
 }
 
 func (r ParquetReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *string) error {

--- a/cmd/pinot_receiver/pinot_receiver.go
+++ b/cmd/pinot_receiver/pinot_receiver.go
@@ -337,8 +337,3 @@ func (r *PinotReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg 
 	*logMsg = "[INFO]: Successfully inserted batch!"
 	return nil
 }
-
-func (r *PinotReceiver) HandleSyncMetric() {
-	req := <-r.SyncChannel
-	log.Println("[INFO]: handle Sync Request", req)
-}

--- a/cmd/s3_receiver/s3_receiver.go
+++ b/cmd/s3_receiver/s3_receiver.go
@@ -145,8 +145,3 @@ func (r *S3Receiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *st
 
 	return nil
 }
-
-func (r *S3Receiver) HandleSyncMetric() {
-	req := <-r.SyncChannel
-	log.Println("[INFO]: handle Sync Request", req)
-}

--- a/cmd/text_receiver/text_receiver.go
+++ b/cmd/text_receiver/text_receiver.go
@@ -55,8 +55,3 @@ func (r TextReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *s
 
 	return nil
 }
-
-func (r TextReceiver) HandleSyncMetric() {
-	req := <-r.SyncChannel
-	log.Println("[INFO]: handled Sync Request", req)
-}

--- a/sinks/sinks_test.go
+++ b/sinks/sinks_test.go
@@ -2,6 +2,7 @@ package sinks
 
 import (
 	"testing"
+	"time"
 
 	"github.com/cybertec-postgresql/pgwatch/v3/api"
 	"github.com/stretchr/testify/assert"
@@ -94,4 +95,25 @@ func TestSyncMetric_EmptyMetric(t *testing.T) {
 	response := new(string)
 	err := handler.SyncMetric(data, response)
 	assert.EqualError(t, err, "Empty Metric Provided.")
+}
+
+func TestHandleSyncMetric(t *testing.T) {
+	handler := NewSyncMetricHandler(1024)
+	// handler routine
+	go handler.HandleSyncMetric()
+
+	logMsg := "test msg"
+	req := &api.RPCSyncRequest{
+		DbName:     "test_database",
+		MetricName: "test_metric",
+		Operation:  "test_op",
+	}
+
+	for range 10 {
+		// issue a channel write
+		handler.SyncMetric(req, &logMsg)
+		time.Sleep(10 * time.Millisecond)
+		// Ensure the Channel has been emptied
+		assert.Equal(t, len(handler.SyncChannel), 0)
+	}
 }

--- a/sinks/types.go
+++ b/sinks/types.go
@@ -3,6 +3,7 @@ package sinks
 import (
 	"errors"
 	"time"
+	"log"
 
 	"github.com/cybertec-postgresql/pgwatch/v3/api"
 )
@@ -42,7 +43,22 @@ func (handler SyncMetricHandler) SyncMetric(syncReq *api.RPCSyncRequest, logMsg 
 	}
 }
 
-func (handler SyncMetricHandler) GetSyncChannelContent() api.RPCSyncRequest {
-	content := <-handler.SyncChannel
-	return content
+func (handler SyncMetricHandler) GetSyncChannelContent() (api.RPCSyncRequest, bool) {
+	content, ok := <-handler.SyncChannel
+	return content, ok
+}
+
+// default HandleSyncMetric() clears the channel
+// in case of the SyncMetric() requests are not 
+// handled by the listening receiver
+func (handler SyncMetricHandler) HandleSyncMetric() {
+	for {
+		req, ok := handler.GetSyncChannelContent()
+		if !ok {
+			// channel is closed
+			return
+		}
+
+		log.Println("[INFO]: handle Sync Request", req)
+	}
 }


### PR DESCRIPTION
1. Modify `HandleSyncMetric()` to loop repeatedly listening for connections and move it to implement SyncMetricHandler instead of repeating it in each sink

2. modify `GetSyncChannelContent()` to return the ok flag and test if the channel were closed or not before listening

3. add `go HandleSyncMetric()` in parquet receiver as it wasn't there