### PR TITLE
refactor: move repeated RPC server registration logic to global Liste…

### DIFF
--- a/cmd/clickhouse_receiver/main.go
+++ b/cmd/clickhouse_receiver/main.go
@@ -9,8 +9,6 @@ import (
 )
 
 func main() {
-
-	// Important Flags
 	port := flag.String("port", "-1", "Specify the port where you want your sink to receive the measurements on.")
 	flag.Parse()
 
@@ -24,11 +22,12 @@ func main() {
 	password := os.Getenv("password")
 	serverURI := os.Getenv("server")
 	dbname := os.Getenv("dbname")
-	log.Println(user, password, serverURI)
 	server, err := NewClickHouseReceiver(user, password, dbname, serverURI, false)
 	if err != nil {
 		log.Fatal("[ERROR]: Unable to create Click house receiver: ", err)
 	}
 
-	sinks.Listen(server, *port)
+	if err = sinks.Listen(server, *port); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/cmd/clickhouse_receiver/main.go
+++ b/cmd/clickhouse_receiver/main.go
@@ -3,9 +3,6 @@ package main
 import (
 	"flag"
 	"log"
-	"net"
-	"net/http"
-	"net/rpc"
 	"os"
 
 	"github.com/destrex271/pgwatch3_rpc_server/sinks"
@@ -33,15 +30,5 @@ func main() {
 		log.Fatal("[ERROR]: Unable to create Click house receiver: ", err)
 	}
 
-	rpc.RegisterName("Receiver", server) // Primary Receiver
-	log.Println("[INFO]: Registered Receiver")
-	rpc.HandleHTTP()
-
-	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	http.Serve(listener, nil)
+	sinks.Listen(server, *port)
 }

--- a/cmd/csv_receiver/main.go
+++ b/cmd/csv_receiver/main.go
@@ -8,8 +8,6 @@ import (
 )
 
 func main() {
-
-	// Important Flags
 	port := flag.String("port", "-1", "Specify the port where you want your sink to receive the measurements on.")
 	StorageFolder := flag.String("rootFolder", ".", "Only for formats like CSV...\n")
 	flag.Parse()
@@ -20,6 +18,7 @@ func main() {
 	}
 
 	server := NewCSVReceiver(*StorageFolder)
-
-	sinks.Listen(server, *port)	
+	if err := sinks.Listen(server, *port); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/cmd/csv_receiver/main.go
+++ b/cmd/csv_receiver/main.go
@@ -3,9 +3,8 @@ package main
 import (
 	"flag"
 	"log"
-	"net"
-	"net/http"
-	"net/rpc"
+
+	"github.com/destrex271/pgwatch3_rpc_server/sinks"
 )
 
 func main() {
@@ -20,22 +19,7 @@ func main() {
 		return
 	}
 
-	// var server sinks.Receiver
-
-	// server = CSVReceiver{FullPath: *StorageFolder, SyncMetricHandler: sinks.NewSyncMetricHandler(1024)}
 	server := NewCSVReceiver(*StorageFolder)
 
-	log.Println("[INFO]: CSV Receiver Intialized")
-
-	rpc.RegisterName("Receiver", server) // Primary Receiver
-	log.Println("[INFO]: Registered Receiver")
-	rpc.HandleHTTP()
-
-	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	http.Serve(listener, nil)
+	sinks.Listen(server, *port)	
 }

--- a/cmd/duckdb_receiver/main.go
+++ b/cmd/duckdb_receiver/main.go
@@ -12,7 +12,6 @@ func main() {
 	port := flag.String("port", "-1", "Specify the port where you want your sink to receive the measurements on.")
 	dbPath := flag.String("dbPath", "metrics.duckdb", "Path to the DuckDB database file")
 	tableName := flag.String("tableName", "measurements", "Name of the measurements table")
-
 	flag.Parse()
 
 	if *port == "-1" {
@@ -22,8 +21,10 @@ func main() {
 
 	server, err := NewDBDuckReceiver(*dbPath, *tableName)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal("[ERROR]: Unable to create DuckDB receiver: ", err)
 	}
 
-	sinks.Listen(server, *port)
+	if err := sinks.Listen(server, *port); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/cmd/duckdb_receiver/main.go
+++ b/cmd/duckdb_receiver/main.go
@@ -3,10 +3,8 @@ package main
 import (
 	"flag"
 	"log"
-	"net"
-	"net/http"
-	"net/rpc"
 
+	"github.com/destrex271/pgwatch3_rpc_server/sinks"
 	_ "github.com/marcboeker/go-duckdb"
 )
 
@@ -22,22 +20,10 @@ func main() {
 		return
 	}
 
-	dbr, err := NewDBDuckReceiver(*dbPath, *tableName)
+	server, err := NewDBDuckReceiver(*dbPath, *tableName)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	rpc.RegisterName("Receiver", dbr) // Primary Receiver
-	log.Println("[INFO]: DuckDB Receiver Initialized with database:", *dbPath)
-	log.Println("[INFO]: Registered Receiver")
-	rpc.HandleHTTP()
-
-	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	http.Serve(listener, nil)
-
+	sinks.Listen(server, *port)
 }

--- a/cmd/kafka_prod_receiver/main.go
+++ b/cmd/kafka_prod_receiver/main.go
@@ -3,9 +3,6 @@ package main
 import (
 	"flag"
 	"log"
-	"net"
-	"net/http"
-	"net/rpc"
 
 	"github.com/destrex271/pgwatch3_rpc_server/sinks"
 )
@@ -29,15 +26,5 @@ func main() {
 		log.Println("[ERROR]: Unable to create Kafka Producer ", err)
 	}
 
-	rpc.RegisterName("Receiver", server) // Primary Receiver
-	log.Println("[INFO]: Registered Receiver")
-	rpc.HandleHTTP()
-
-	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	http.Serve(listener, nil)
+	sinks.Listen(server, *port)	
 }

--- a/cmd/kafka_prod_receiver/main.go
+++ b/cmd/kafka_prod_receiver/main.go
@@ -8,8 +8,6 @@ import (
 )
 
 func main() {
-
-	// Important Flags
 	port := flag.String("port", "-1", "Specify the port where you want your sink to receive the measurements on.")
 	kafkaHost := flag.String("kafkaHost", "localhost:9092", "Specify the host and port of the kafka instance")
 	autoadd := flag.Bool("autoadd", true, "Specifies if new databases are automatically added as a new kafka topic. Default is true. You can disable this service and send an 'ADD' sync metric signal before sending data")
@@ -26,5 +24,7 @@ func main() {
 		log.Println("[ERROR]: Unable to create Kafka Producer ", err)
 	}
 
-	sinks.Listen(server, *port)	
+	if err := sinks.Listen(server, *port); err != nil {
+		log.Fatal(err)
+	}	
 }

--- a/cmd/llama_receiver/main.go
+++ b/cmd/llama_receiver/main.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"flag"
 	"log"
-	"net"
-	"net/http"
-	"net/rpc"
 	"os"
 	"os/exec"
 
@@ -34,16 +31,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	rpc.RegisterName("Receiver", server) // Primary Receiver
-	log.Println("[INFO]: Registered Receiver")
-	rpc.HandleHTTP()
-
-	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	if *enableAPI {
 		go func() {
 			os.Setenv("pgURI", *pgURI)
@@ -59,5 +46,5 @@ func main() {
 
 	}
 
-	http.Serve(listener, nil)
+	sinks.Listen(server, *port)
 }

--- a/cmd/llama_receiver/main.go
+++ b/cmd/llama_receiver/main.go
@@ -11,8 +11,6 @@ import (
 )
 
 func main() {
-	// Important Flags
-	// receiverType := flag.String("type", "", "The type of sink that you want to keep this node as.\nAvailable options:\n\t- csv\n\t- text\n\t- parquet")
 	port := flag.String("port", "-1", "Specify the port where you want your sink to receive the measurements on.")
 	serverURI := flag.String("ollamaURI", "http://localhost:11434", "URI for Ollama server")
 	pgURI := flag.String("pgURI", "postgres://pgwatch:pgwatchadmin@localhost:5432/postgres", "connection string for postgres")
@@ -43,8 +41,9 @@ func main() {
 				log.Println("[INFO]: You can start the dashbaord using npm run dev")
 			}
 		}()
-
 	}
 
-	sinks.Listen(server, *port)
+	if err := sinks.Listen(server, *port); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/cmd/parquet_receiver/main.go
+++ b/cmd/parquet_receiver/main.go
@@ -10,7 +10,6 @@ import (
 func main() {
 	port := flag.String("port", "-1", "Specify the port where you want your sink to receive the measurements on.")
 	StorageFolder := flag.String("rootFolder", ".", "Only for formats like CSV...\n")
-
 	flag.Parse()
 
 	if *port == "-1" {
@@ -19,6 +18,7 @@ func main() {
 	}
 
 	server := NewParquetReceiver(*StorageFolder)
-
-	sinks.Listen(server, *port)	
+	if err := sinks.Listen(server, *port); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/cmd/parquet_receiver/main.go
+++ b/cmd/parquet_receiver/main.go
@@ -3,9 +3,8 @@ package main
 import (
 	"flag"
 	"log"
-	"net"
-	"net/http"
-	"net/rpc"
+
+	"github.com/destrex271/pgwatch3_rpc_server/sinks"
 )
 
 func main() {
@@ -21,15 +20,5 @@ func main() {
 
 	server := NewParquetReceiver(*StorageFolder)
 
-	rpc.RegisterName("Receiver", server)
-	log.Println("[INFO]: Registered Receiver")
-	rpc.HandleHTTP()
-
-	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	http.Serve(listener, nil)
+	sinks.Listen(server, *port)	
 }

--- a/cmd/pinot_receiver/main.go
+++ b/cmd/pinot_receiver/main.go
@@ -84,5 +84,7 @@ func main() {
 
 	log.Println("[INFO]: Pinot Receiver Initialized")
 
-	sinks.Listen(server, *port)	
+	if err := sinks.Listen(server, *port); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/cmd/pinot_receiver/main.go
+++ b/cmd/pinot_receiver/main.go
@@ -4,12 +4,11 @@ import (
 	"encoding/json"
 	"flag"
 	"log"
-	"net"
-	"net/http"
-	"net/rpc"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/destrex271/pgwatch3_rpc_server/sinks"
 )
 
 func main() {
@@ -85,16 +84,5 @@ func main() {
 
 	log.Println("[INFO]: Pinot Receiver Initialized")
 
-	rpc.RegisterName("Receiver", server) // Primary Receiver
-	log.Println("[INFO]: Registered Receiver")
-	rpc.HandleHTTP()
-
-	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)
-	if err != nil {
-		log.Fatalf("[ERROR]: Failed to start listener: %v", err)
-		return
-	}
-
-	log.Printf("[INFO]: Server started, listening on port %s", *port)
-	http.Serve(listener, nil)
+	sinks.Listen(server, *port)	
 }

--- a/cmd/s3_receiver/main.go
+++ b/cmd/s3_receiver/main.go
@@ -3,9 +3,6 @@ package main
 import (
 	"flag"
 	"log"
-	"net"
-	"net/http"
-	"net/rpc"
 	"os"
 
 	"github.com/destrex271/pgwatch3_rpc_server/sinks"
@@ -33,15 +30,5 @@ func main() {
 		log.Fatal("[ERROR]: Unable to setup receiver")
 	}
 
-	rpc.RegisterName("Receiver", server) // Primary Receiver
-	log.Println("[INFO]: Registered Receiver")
-	rpc.HandleHTTP()
-
-	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	http.Serve(listener, nil)
+	sinks.Listen(server, *port)	
 }

--- a/cmd/s3_receiver/main.go
+++ b/cmd/s3_receiver/main.go
@@ -9,9 +9,6 @@ import (
 )
 
 func main() {
-
-	// Important Flags
-	// receiverType := flag.String("type", "", "The type of sink that you want to keep this node as.\nAvailable options:\n\t- csv\n\t- text\n\t- parquet")
 	port := flag.String("port", "-1", "Specify the port where you want your sink to receive the measurements on.")
 	awsEndpoint := flag.String("awsEndpoint", "", "Specify aws endpoint")
 	awsRegion := flag.String("awsRegion", "us-east-1", "Specify AWS region")
@@ -27,8 +24,10 @@ func main() {
 	var server sinks.Receiver
 	server, err := NewS3Receiver(*awsEndpoint, *awsRegion, username, password)
 	if err != nil {
-		log.Fatal("[ERROR]: Unable to setup receiver")
+		log.Fatal("[ERROR]: Unable to create S3 receiver", err)
 	}
 
-	sinks.Listen(server, *port)	
+	if err := sinks.Listen(server, *port); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/cmd/text_receiver/main.go
+++ b/cmd/text_receiver/main.go
@@ -3,9 +3,8 @@ package main
 import (
 	"flag"
 	"log"
-	"net"
-	"net/http"
-	"net/rpc"
+
+	"github.com/destrex271/pgwatch3_rpc_server/sinks"
 )
 
 func main() {
@@ -23,15 +22,5 @@ func main() {
 
 	server := NewTextReceiver(*StorageFolder)
 
-	rpc.RegisterName("Receiver", server) // Primary Receiver
-	log.Println("[INFO]: Registered Receiver")
-	rpc.HandleHTTP()
-
-	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	http.Serve(listener, nil)
+	sinks.Listen(server, *port)
 }

--- a/cmd/text_receiver/main.go
+++ b/cmd/text_receiver/main.go
@@ -8,9 +8,6 @@ import (
 )
 
 func main() {
-
-	// Important Flags
-	// receiverType := flag.String("type", "", "The type of sink that you want to keep this node as.\nAvailable options:\n\t- csv\n\t- text\n\t- parquet")
 	port := flag.String("port", "-1", "Specify the port where you want your sink to receive the measurements on.")
 	StorageFolder := flag.String("rootFolder", ".", "Only for formats like CSV...\n")
 	flag.Parse()
@@ -21,6 +18,7 @@ func main() {
 	}
 
 	server := NewTextReceiver(*StorageFolder)
-
-	sinks.Listen(server, *port)
+	if err := sinks.Listen(server, *port); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/sinks/common.go
+++ b/sinks/common.go
@@ -19,16 +19,16 @@ func GetJson[K map[string]string | map[string]any | float64 | api.MeasurementEnv
 	return string(jsonString)
 }
 
-func Listen(server Receiver, port string) {
-	rpc.RegisterName("Receiver", server) // Primary Receiver
+func Listen(server Receiver, port string) error {
+	rpc.RegisterName("Receiver", server) 
 	rpc.HandleHTTP()
 
 	listener, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%s", port))
-
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	log.Println("[INFO]: Registered Receiver")
 	http.Serve(listener, nil)
+	return nil
 }

--- a/sinks/common.go
+++ b/sinks/common.go
@@ -2,7 +2,11 @@ package sinks
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
+	"net"
+	"net/rpc"
+	"net/http"
 
 	"github.com/cybertec-postgresql/pgwatch/v3/api"
 )
@@ -13,4 +17,18 @@ func GetJson[K map[string]string | map[string]any | float64 | api.MeasurementEnv
 		log.Default().Fatal("[ERROR]: Unable to parse Metric Definition")
 	}
 	return string(jsonString)
+}
+
+func Listen(server Receiver, port string) {
+	rpc.RegisterName("Receiver", server) // Primary Receiver
+	rpc.HandleHTTP()
+
+	listener, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%s", port))
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println("[INFO]: Registered Receiver")
+	http.Serve(listener, nil)
 }


### PR DESCRIPTION
The RPC Server Registration logic is being repeated in all sinks
```
        rpc.RegisterName("Receiver", server) // Primary Receiver
	log.Println("[INFO]: Registered Receiver")
	rpc.HandleHTTP()

	listener, err := net.Listen("tcp", "0.0.0.0:"+*port)

	if err != nil {
		log.Fatal(err)
	}

	http.Serve(listener, nil)
```

## changes 
it has been moved to a global Listen(Receiver, port) method in sinks/common.go and all sinks have been updated accordingly
```
func Listen(server Receiver, port string) {
	rpc.RegisterName("Receiver", server) // Primary Receiver
	rpc.HandleHTTP()

	listener, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%s", port))

	if err != nil {
		log.Fatal(err)
	}

	log.Println("[INFO]: Registered Receiver")
	http.Serve(listener, nil)
}
```
closes: #57 
