### PR TITLE
Change kafka test-container to wait for server start log message

### DIFF
--- a/cmd/kafka_prod_receiver/kafka_prod_receiver_test.go
+++ b/cmd/kafka_prod_receiver/kafka_prod_receiver_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cybertec-postgresql/pgwatch/v3/api"
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,7 @@ func initContainer(ctx context.Context) (testcontainers.Container, error) {
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image:        "apache/kafka:latest",
 			ExposedPorts: []string{"9092:9092"},
-			WaitingFor:   wait.ForListeningPort("9092"),
+			WaitingFor:   wait.ForLog("Kafka Server started").WithStartupTimeout(120 * time.Second),
 			WorkingDir:   "/opt/kafka/bin/",
 		},
 		Started: true,


### PR DESCRIPTION
The logs of failing errors show that the test fails immediately
```
Warning: 1 19:32:47 [WARNING]: Connection does not exist for database test
2025/05/21 19:32:47 [INFO]: Adding database test since Auto Add is enabled. You can disable it by restarting the sink with autoadd option as false
Error: /21 19:32:47 [ERROR]: Unable to create new connection
```
so the error is not a timeout and given that it don't always fail so its probably an issue with the full startup of the kafka service under github CI

This PR updates the wait strategy for the test container to wait for the kafka service start log message
`[2025-05-24 01:50:41,910] INFO [KafkaRaftServer nodeId=1] Kafka Server started (kafka.server.KafkaRaftServer)`
```
...
WaitingFor:   wait.ForLog("Kafka Server started").WithStartupTimeout(120 * time.Second),
...
```
fixes: #59