### PR TITLE
add Golang lint CI test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    name: Build and Lint
+    runs-on: ubuntu-latest
+    steps:  
+
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Golang
+        uses: actions/setup-go@v5
+
+      - name: GolangCI-Lint 
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build and Lint
+  Lint:
     runs-on: ubuntu-latest
     steps:  
 
@@ -31,7 +30,7 @@ jobs:
         with:
           version: latest
 
-  test:
+  Test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/cmd/csv_receiver/csv_receiver.go
+++ b/cmd/csv_receiver/csv_receiver.go
@@ -35,13 +35,13 @@ func NewCSVReceiver(fullPath string) (tr *CSVReceiver) {
 
 func (r CSVReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *string) error {
 	if len(msg.DBName) == 0 {
-		return errors.New("Empty Database")
+		return errors.New("empty database")
 	}
 
 	// Open/Create Output file
 	superFolder := msg.DBName
 	if len(msg.MetricName) == 0 {
-		return errors.New("Unidentifiable Metric Name: EMPTY")
+		return errors.New("unidentifiable metric name: EMPTY")
 	}
 	fileName := msg.MetricName + ".csv"
 

--- a/cmd/csv_receiver/csv_receiver_test.go
+++ b/cmd/csv_receiver/csv_receiver_test.go
@@ -71,7 +71,7 @@ func TestUpdateMeasurements_CSV_ValidData(t *testing.T) {
 	assert.FileExists(t, fullPath+"/"+msg.DBName+"/"+msg.MetricName+".csv", "CSV file not found for metric")
 
 	// Cleanup
-	os.RemoveAll(fullPath + "/" + msg.DBName)
+	_ = os.RemoveAll(fullPath + "/" + msg.DBName)
 }
 
 func TestUpdateMeasurements_CSV_EmptyDBName(t *testing.T) {
@@ -96,7 +96,7 @@ func TestUpdateMeasurements_CSV_EmptyDBName(t *testing.T) {
 	err = recv.UpdateMeasurements(msg, logMsg)
 
 	assert.NotNil(t, err, "No error thrown for empty Database Name")
-	assert.EqualError(t, err, "Empty Database", "Invalid Error Message")
+	assert.EqualError(t, err, "empty database", "Invalid Error Message")
 }
 
 func TestUpdateMeasurements_CSV_EmptyMetricName(t *testing.T) {
@@ -120,5 +120,5 @@ func TestUpdateMeasurements_CSV_EmptyMetricName(t *testing.T) {
 	err = recv.UpdateMeasurements(msg, logMsg)
 
 	assert.NotNil(t, err, "No error thrown for empty Metric Name")
-	assert.EqualError(t, err, "Unidentifiable Metric Name: EMPTY", "Invalid Error Message for empty metric name")
+	assert.EqualError(t, err, "unidentifiable metric name: EMPTY", "Invalid Error Message for empty metric name")
 }

--- a/cmd/duckdb_receiver/duckdb_receiver.go
+++ b/cmd/duckdb_receiver/duckdb_receiver.go
@@ -73,16 +73,16 @@ func (r *DuckDBReceiver) InsertMeasurements(data *api.MeasurementEnvelope, ctx c
 		" (dbname, metric_name, data, custom_tags, metric_def, timestamp) VALUES (?, ?, ?, ?, ?, ?)")
 	if err != nil {
 		log.Printf("error from preparing statement: %v", err)
-		tx.Rollback()
+		_ = tx.Rollback()
 		return err
 	}
-	defer stmt.Close()
+	defer func() {_ = stmt.Close()}()
 
 	for _, measurement := range data.Data {
 		measurementJSON, err := json.Marshal(measurement)
 		if err != nil {
 			log.Printf("error from marshal measurement: %v", err)
-			tx.Rollback()
+			_ = tx.Rollback()
 			return err
 		}
 
@@ -96,7 +96,7 @@ func (r *DuckDBReceiver) InsertMeasurements(data *api.MeasurementEnvelope, ctx c
 		)
 		if err != nil {
 			log.Printf("error from insert: %v", err)
-			tx.Rollback()
+			_ = tx.Rollback()
 			return err
 		}
 	}

--- a/cmd/kafka_prod_receiver/kafka_prod_receiver.go
+++ b/cmd/kafka_prod_receiver/kafka_prod_receiver.go
@@ -27,11 +27,16 @@ func (r *KafkaProdReceiver) HandleSyncMetric() {
 			return
 		}
 
+		var err error
 		switch req.Operation {
 		case api.DeleteOp:
-			r.CloseConnectionForDB(req.DbName)
+			err = r.CloseConnectionForDB(req.DbName)
 		case api.AddOp:
-			r.AddTopicIfNotExists(req.DbName)
+			err = r.AddTopicIfNotExists(req.DbName)
+		}
+
+		if err != nil {
+			log.Printf("[ERROR] error handling Kafka SyncMetric operation: %s", err)
 		}
 	}
 }

--- a/cmd/kafka_prod_receiver/kafka_prod_receiver_test.go
+++ b/cmd/kafka_prod_receiver/kafka_prod_receiver_test.go
@@ -66,7 +66,7 @@ func TestNewKafkaProducer(t *testing.T) {
 	container, err := initContainer(context.Background())
 	defer func() {
 		t.Log("Terminating test container")
-		container.Terminate(context.Background())
+		_ = container.Terminate(context.Background())
 	}()
 
 	if err != nil {
@@ -86,7 +86,7 @@ func TestUpdateMeasurements_KAFKA_ValidData(t *testing.T) {
 	container, err := initContainer(context.Background())
 	defer func() {
 		t.Log("Terminating test container...")
-		container.Terminate(context.Background())
+		_ = container.Terminate(context.Background())
 	}()
 
 	if err != nil {
@@ -106,10 +106,10 @@ func TestUpdateMeasurements_KAFKA_ValidData(t *testing.T) {
 	// Check if connection was succesfully established
 	assert.Nil(t, err, "Error encoutered while adding new measurements")
 
-	// Try to consume data added to topicc
+	// Try to consume data added to topic
 	cmd := []string{"timeout", "10s", "/opt/kafka/bin/kafka-console-consumer.sh", "--bootstrap-server", "localhost:9092", "--topic", "test", "--from-beginning"}
 	_, reader, err := container.Exec(context.Background(), cmd)
-	// _, reader, err := container.Exec(context.Background(), []string{"ls"})
+	assert.NoError(t, err)
 
 	buf := new(strings.Builder)
 	_, err = io.Copy(buf, reader)
@@ -120,6 +120,7 @@ func TestUpdateMeasurements_KAFKA_ValidData(t *testing.T) {
 	// See the logs from the command execution.
 	t.Log(buf)
 	msg_as_str, err := json.Marshal(msg)
+	assert.NoError(t, err)
 	assert.True(t, strings.Contains(buf.String(), string(msg_as_str)), "Unable to retrieve measurements from topic")
 }
 
@@ -128,7 +129,7 @@ func TestUpdateMeasurements_KAFKA_EmptyDatabase(t *testing.T) {
 	container, err := initContainer(context.Background())
 	defer func() {
 		t.Log("Terminating test container")
-		container.Terminate(context.Background())
+		_ = container.Terminate(context.Background())
 	}()
 
 	if err != nil {
@@ -156,7 +157,7 @@ func TestUpdateMeasurements_KAFKA_EmptyMetricName(t *testing.T) {
 	container, err := initContainer(context.Background())
 	defer func() {
 		t.Log("Terminating test container")
-		container.Terminate(context.Background())
+		_ = container.Terminate(context.Background())
 	}()
 
 	if err != nil {

--- a/cmd/llama_receiver/llama_receiver.go
+++ b/cmd/llama_receiver/llama_receiver.go
@@ -121,9 +121,13 @@ func (r *LlamaReceiver) HandleSyncMetric() {
 
 		switch req.Operation {
 		case api.AddOp:
-			conn.Exec(r.Ctx, `INSERT INTO db(dbname) VALUES($1)`, req.DbName)
+			_, err = conn.Exec(r.Ctx, `INSERT INTO db(dbname) VALUES($1)`, req.DbName)
 		case api.DeleteOp:
-			conn.Exec(r.Ctx, `DELETE FROM db WHERE dbanme=$1 CASCADE;`, req.DbName)
+			_, err = conn.Exec(r.Ctx, `DELETE FROM db WHERE dbanme=$1 CASCADE;`, req.DbName)
+		}
+
+		if err != nil {
+			log.Printf("[ERROR] error handling LLama SyncMetric operation: %s", err)
 		}
 	}
 }
@@ -396,7 +400,7 @@ func (r *LlamaReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg 
 				go func(val *api.MeasurementEnvelope) {
 					r.mu.Lock()
 					defer r.mu.Unlock()
-					r.GenerateInsights(*val)
+					_ = r.GenerateInsights(*val)
 				}(val)
 			}
 		}

--- a/cmd/llama_receiver/llama_receiver_test.go
+++ b/cmd/llama_receiver/llama_receiver_test.go
@@ -32,7 +32,7 @@ func initOllamaContainer(ctx context.Context) (*tcollama.OllamaContainer, error)
 			log.Println("unable to pull llama3: " + err.Error())
 			return nil, err
 		}
-		ollamaContainer.Commit(ctx, new_image)
+		_ = ollamaContainer.Commit(ctx, new_image)
 	}
 
 	return ollamaContainer, nil

--- a/cmd/llama_receiver/main.go
+++ b/cmd/llama_receiver/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	if *enableAPI {
 		go func() {
-			os.Setenv("pgURI", *pgURI)
+			_ = os.Setenv("pgURI", *pgURI)
 			cmnd := exec.Command("./cmd/llama_receiver/backend/main")
 			log.Println(cmnd)
 			err = cmnd.Start()

--- a/cmd/parquet_receiver/parquet_receiver.go
+++ b/cmd/parquet_receiver/parquet_receiver.go
@@ -41,22 +41,22 @@ func (r ParquetReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg
 
 	if len(msg.DBName) == 0 {
 		*logMsg = "False Record delieverd"
-		return errors.New("Empty Database")
+		return errors.New("empty database")
 	}
 
 	if len(msg.MetricName) == 0 {
 		*logMsg = "False Record delievered"
-		return errors.New("Empty Metric Name")
+		return errors.New("empty metric name")
 	}
 
 	filename := msg.DBName + ".parquet"
 
 	// Create temporary storage and buffer storage
 	buffer_path := r.FullPath + "/parquet_readings"
-	os.MkdirAll(buffer_path, os.ModePerm)
+	_ = os.MkdirAll(buffer_path, os.ModePerm)
 
 	if _, err := os.Stat(buffer_path + "/" + filename); errors.Is(err, os.ErrNotExist) {
-		os.Create(buffer_path + "/" + filename)
+		_, _ = os.Create(buffer_path + "/" + filename)
 		log.Println("[INFO]: Created File")
 	}
 

--- a/cmd/parquet_receiver/parquet_receiver_test.go
+++ b/cmd/parquet_receiver/parquet_receiver_test.go
@@ -64,7 +64,7 @@ func TestUpdateMeasurements_PARQ(t *testing.T) {
 	assert.FileExists(t, fullPath+"/parquet_readings/"+msg.DBName+".parquet", "CSV file not found for metric")
 
 	// Cleanup
-	os.RemoveAll(fullPath + "/parquet_readings")
+	_ = os.RemoveAll(fullPath + "/parquet_readings")
 }
 
 func TestUpdateMeasurements_PARQ_EmptyDBName(t *testing.T) {
@@ -84,7 +84,7 @@ func TestUpdateMeasurements_PARQ_EmptyDBName(t *testing.T) {
 	err = recv.UpdateMeasurements(msg, logMsg)
 
 	// Check if there were any errors while updating measurements
-	assert.EqualError(t, err, "Empty Database", "Error Message not thrown for empty database name")
+	assert.EqualError(t, err, "empty database", "Error Message not thrown for empty database name")
 
 	// Check if directories were not created
 	if _, err := os.Stat(fullPath + "/parquet_readings"); err != nil {
@@ -109,7 +109,7 @@ func TestUpdateMeasurements_PARQ_EmptyMetricName(t *testing.T) {
 	err = recv.UpdateMeasurements(msg, logMsg)
 
 	// Check if there were any errors while updating measurements
-	assert.EqualError(t, err, "Empty Metric Name", "Error Message not thrown for empty metric name")
+	assert.EqualError(t, err, "empty metric name", "Error Message not thrown for empty metric name")
 
 	// Check if directories were not created
 	if _, err := os.Stat(fullPath + "/parquet_readings"); err != nil {

--- a/cmd/pinot_receiver/main.go
+++ b/cmd/pinot_receiver/main.go
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	// Simple URL fix - handle port-only case and add http:// if needed
-	if strings.Contains(*pinotControllerURL, ".") == false && strings.Contains(*pinotControllerURL, ":") == false {
+	if !strings.Contains(*pinotControllerURL, ".") && !strings.Contains(*pinotControllerURL, ":") {
 		// Just a port number
 		*pinotControllerURL = "http://localhost:" + *pinotControllerURL
 	} else if !strings.HasPrefix(*pinotControllerURL, "http") {

--- a/cmd/pinot_receiver/pinot_receiver.go
+++ b/cmd/pinot_receiver/pinot_receiver.go
@@ -141,7 +141,7 @@ func (r *PinotReceiver) uploadSchema(schemaPath string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {_ = resp.Body.Close()}()
 
 	// Check response
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
@@ -187,7 +187,7 @@ func (r *PinotReceiver) createTable(tableConfigPath string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {_ = resp.Body.Close()}()
 
 	// Check response (table might already exist, which is fine)
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
@@ -228,13 +228,13 @@ func (r *PinotReceiver) insertData(dbName, metricName string, data, customTags, 
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %v", err)
 	}
-	defer os.Remove(tempFile.Name())
-	defer tempFile.Close()
+	defer func() {_ = os.Remove(tempFile.Name())}()
+	defer func() {_ = tempFile.Close()}()
 
 	if _, err := tempFile.Write(jsonData); err != nil {
 		return fmt.Errorf("failed to write to temp file: %v", err)
 	}
-	tempFile.Close() // Close the file before reading it
+	_ = tempFile.Close() // Close the file before reading it
 
 	// Create a buffer to hold the multipart form data
 	var buffer bytes.Buffer
@@ -245,7 +245,7 @@ func (r *PinotReceiver) insertData(dbName, metricName string, data, customTags, 
 	if err != nil {
 		return fmt.Errorf("failed to open temp file: %v", err)
 	}
-	defer fileReader.Close()
+	defer func() {_ = fileReader.Close()}()
 
 	// Add the file to the form
 	filePart, err := writer.CreateFormFile("file", "data.json")
@@ -281,7 +281,7 @@ func (r *PinotReceiver) insertData(dbName, metricName string, data, customTags, 
 	if err != nil {
 		return fmt.Errorf("failed to send request: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {_ = resp.Body.Close()}()
 
 	// Read and log the response
 	body, _ := io.ReadAll(resp.Body)

--- a/cmd/pinot_receiver/pinot_receiver_test.go
+++ b/cmd/pinot_receiver/pinot_receiver_test.go
@@ -41,7 +41,7 @@ func mockHTTPServer() *httptest.Server {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"success"}`))
+		_, _ = w.Write([]byte(`{"status":"success"}`))
 	})
 
 	return httptest.NewServer(handler)
@@ -93,7 +93,7 @@ func setupTestConfigDir(t *testing.T) (string, func()) {
 	assert.NoError(t, err, "Failed to write table.json")
 
 	cleanup := func() {
-		os.RemoveAll(tempDir)
+		_ = os.RemoveAll(tempDir)
 	}
 
 	return tempDir, cleanup
@@ -154,14 +154,14 @@ func TestInitializePinotTable(t *testing.T) {
 	configDir, cleanup := setupTestConfigDir(t)
 	defer cleanup()
 
-	receiver, err := NewPinotReceiver(server.URL, "pgwatch_metrics", configDir)
+	_, err := NewPinotReceiver(server.URL, "pgwatch_metrics", configDir)
 	assert.NoError(t, err, "NewPinotReceiver should initialize without error")
 
 	// Test is already covered by initialization, but we can add additional test cases:
 
 	// Test with missing schema file
-	os.Remove(filepath.Join(configDir, "schema.json"))
-	receiver = &PinotReceiver{
+	_ = os.Remove(filepath.Join(configDir, "schema.json"))
+	receiver := &PinotReceiver{
 		ControllerURL:     server.URL,
 		TableName:         "pgwatch_metrics",
 		ConfigDir:         configDir,

--- a/cmd/s3_receiver/s3_receiver_test.go
+++ b/cmd/s3_receiver/s3_receiver_test.go
@@ -74,7 +74,7 @@ func TestNewS3Receiver(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer provider.Close()
+	defer func() {_ = provider.Close()}()
 
 	host, err := provider.DaemonHost(ctx)
 	if err != nil {
@@ -110,7 +110,7 @@ func TestAddDatabase(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer provider.Close()
+	defer func() {_ = provider.Close()}()
 
 	host, err := provider.DaemonHost(ctx)
 	if err != nil {
@@ -123,7 +123,8 @@ func TestAddDatabase(t *testing.T) {
 	assert.NotNil(t, client, "received nil instead of client")
 
 	dbname := "test-db"
-	client.AddDatabase(dbname)
+	err = client.AddDatabase(dbname)
+	assert.NoError(t, err)
 
 	res, err := client.DBExists(dbname)
 
@@ -153,7 +154,7 @@ func TestUpdateMeasurements_VALID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer provider.Close()
+	defer func() {_ = provider.Close()}()
 
 	host, err := provider.DaemonHost(ctx)
 	if err != nil {
@@ -194,7 +195,7 @@ func TestUpdateMeasurements_EMPTYDB(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer provider.Close()
+	defer func() {_ = provider.Close()}()
 
 	host, err := provider.DaemonHost(ctx)
 	if err != nil {
@@ -236,7 +237,7 @@ func TestUpdateMeasurements_EMPTY_METRIC_NAME(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer provider.Close()
+	defer func() {_ = provider.Close()}()
 
 	host, err := provider.DaemonHost(ctx)
 	if err != nil {
@@ -278,7 +279,7 @@ func TestUpdateMeasurements_EMPTY_METRICS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer provider.Close()
+	defer func() {_ = provider.Close()}()
 
 	host, err := provider.DaemonHost(ctx)
 	if err != nil {

--- a/cmd/text_receiver/text_receiver.go
+++ b/cmd/text_receiver/text_receiver.go
@@ -40,7 +40,7 @@ func (r TextReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *s
 	}
 
 	writer := bufio.NewWriter(file)
-	defer file.Close()
+	defer func() {_ = file.Close()}()
 
 	output := "DBName: " + msg.DBName + "\n" + "Metric: " + msg.MetricName + "\n"
 
@@ -50,8 +50,9 @@ func (r TextReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *s
 
 	output += "\n===================================\n"
 
-	fmt.Fprintln(writer, output)
-	writer.Flush()
-
-	return nil
+	_, err = fmt.Fprintln(writer, output)
+	if err != nil {
+		return err
+	}
+	return writer.Flush()
 }

--- a/sinks/common.go
+++ b/sinks/common.go
@@ -20,7 +20,10 @@ func GetJson[K map[string]string | map[string]any | float64 | api.MeasurementEnv
 }
 
 func Listen(server Receiver, port string) error {
-	rpc.RegisterName("Receiver", server) 
+	err := rpc.RegisterName("Receiver", server) 
+	if err != nil {
+		return err
+	}
 	rpc.HandleHTTP()
 
 	listener, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%s", port))
@@ -29,6 +32,5 @@ func Listen(server Receiver, port string) error {
 	}
 
 	log.Println("[INFO]: Registered Receiver")
-	http.Serve(listener, nil)
-	return nil
+	return http.Serve(listener, nil)
 }

--- a/sinks/sinks_test.go
+++ b/sinks/sinks_test.go
@@ -58,7 +58,7 @@ func TestSyncMetric_InvalidOperation(t *testing.T) {
 	// Send data to Sync Metric Handler and check if it returns any error
 	response := new(string)
 	err := handler.SyncMetric(data, response)
-	assert.EqualError(t, err, "Invalid Operation type.")
+	assert.EqualError(t, err, "invalid operation type")
 }
 
 func TestSyncMetric_EmptyDatabase(t *testing.T) {
@@ -76,7 +76,7 @@ func TestSyncMetric_EmptyDatabase(t *testing.T) {
 	// Send data to Sync Metric Handler and check if it returns any errosr
 	response := new(string)
 	err := handler.SyncMetric(data, response)
-	assert.EqualError(t, err, "Empty Database.")
+	assert.EqualError(t, err, "empty database")
 }
 
 func TestSyncMetric_EmptyMetric(t *testing.T) {
@@ -94,7 +94,7 @@ func TestSyncMetric_EmptyMetric(t *testing.T) {
 	// Send data to Sync Metric Handler and check if it returns any errosr
 	response := new(string)
 	err := handler.SyncMetric(data, response)
-	assert.EqualError(t, err, "Empty Metric Provided.")
+	assert.EqualError(t, err, "empty metric provided")
 }
 
 func TestHandleSyncMetric(t *testing.T) {
@@ -105,7 +105,7 @@ func TestHandleSyncMetric(t *testing.T) {
 	logMsg := "test msg"
 	for range 10 {
 		// issue a channel write
-		handler.SyncMetric(getTestRPCSyncRequest(), &logMsg)
+		_ = handler.SyncMetric(getTestRPCSyncRequest(), &logMsg)
 		time.Sleep(10 * time.Millisecond)
 		// Ensure the Channel has been emptied
 		assert.Equal(t, len(handler.SyncChannel), 0)

--- a/sinks/types.go
+++ b/sinks/types.go
@@ -26,20 +26,20 @@ func NewSyncMetricHandler(chanSize int) SyncMetricHandler {
 
 func (handler SyncMetricHandler) SyncMetric(syncReq *api.RPCSyncRequest, logMsg *string) error {
 	if syncReq.Operation != api.AddOp && syncReq.Operation != api.DeleteOp {
-		return errors.New("Invalid Operation type.")
+		return errors.New("invalid operation type")
 	}
 	if len(syncReq.DbName) == 0 {
-		return errors.New("Empty Database.")
+		return errors.New("empty database")
 	}
 	if len(syncReq.MetricName) == 0 {
-		return errors.New("Empty Metric Provided.")
+		return errors.New("empty metric provided")
 	}
 
 	select {
 	case handler.SyncChannel <- *syncReq:
 		return nil
 	case <-time.After(5 * time.Second):
-		return errors.New("Timeout while trying to sync metric")
+		return errors.New("timeout while trying to sync metric")
 	}
 }
 


### PR DESCRIPTION
add Golang lint CI test.
fix old formatting issues.

note: most `return type not checked` errors has been solved by adding `_ =` while they can require better handling, this was left to be handled by future refactoring for individual sinks
closes: #65 