### PR TITLE
migrate LLama and kafka to grpc

### DIFF
--- a/cmd/clickhouse_receiver/clickhouse_receiver.go
+++ b/cmd/clickhouse_receiver/clickhouse_receiver.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -12,162 +11,114 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/cybertec-postgresql/pgwatch/v3/api"
 	"github.com/destrex271/pgwatch3_rpc_server/sinks"
+	"github.com/destrex271/pgwatch3_rpc_server/sinks/pb"
 )
 
 type ClickHouseReceiver struct {
-	Ctx  context.Context
 	Conn driver.Conn
 	sinks.SyncMetricHandler
 	Engine string
 }
 
-func GetConnection(user string, password string, dbname string, serverURI string, isTest bool) (driver.Conn, error) {
-	dialCount := 0
-
+func GetConnection(User string, Password string, DBName string, serverURI string, isTest bool) (driver.Conn, error) {
 	var conn driver.Conn
 	var err error
+	dialCount := 0
+
+	options := &clickhouse.Options{
+		Addr:     []string{serverURI},
+		Protocol: clickhouse.Native,
+		Auth: clickhouse.Auth{
+			Database: DBName,
+			Username: User,
+			Password: Password,
+		},
+		TLS: &tls.Config{},
+	}
 
 	if isTest {
-		conn, err = clickhouse.Open(&clickhouse.Options{
-			Addr:     []string{serverURI},
-			Protocol: clickhouse.Native,
-			Auth: clickhouse.Auth{
-				Database: dbname,
-				Username: user,
-				Password: password,
-			},
-			DialContext: func(ctx context.Context, addr string) (net.Conn, error) {
-				dialCount++
-				var d net.Dialer
-				return d.DialContext(ctx, "tcp", addr)
-			},
-			TLS: &tls.Config{},
-		})
-
-	} else {
-		log.Println("Getting normal connection")
-		conn, err = clickhouse.Open(&clickhouse.Options{
-			Addr:     []string{serverURI},
-			Protocol: clickhouse.Native,
-			Auth: clickhouse.Auth{
-				Database: dbname,
-				Username: user,
-				Password: password,
-			},
-			TLS: &tls.Config{},
-		})
+		options.DialContext = func(ctx context.Context, addr string) (net.Conn, error) {
+			dialCount++
+			var d net.Dialer
+			return d.DialContext(ctx, "tcp", addr)
+		}
 	}
 
-	log.Println(conn)
+	conn, err = clickhouse.Open(options)
 	if err != nil {
 		return nil, err
 	}
-
 	err = conn.Ping(context.Background())
-	log.Println(err)
-	if err != nil {
-		return nil, err
-	}
 	return conn, err
 }
 
-func NewClickHouseReceiver(user string, password string, dbname string, serverURI string, isTest bool) (chr *ClickHouseReceiver, err error) {
-	// Get clickhouse connection
-	conn, err := GetConnection(user, password, dbname, serverURI, isTest)
+func NewClickHouseReceiver(User string, Password string, DBName string, serverURI string, isTest bool) (*ClickHouseReceiver, error) {
+	conn, err := GetConnection(User, Password, DBName, serverURI, isTest)
 	if err != nil {
 		return nil, err
 	}
 
-	// Create new struct
-	clickhouseRec := &ClickHouseReceiver{
+	chr := &ClickHouseReceiver{
 		Conn:              conn,
 		SyncMetricHandler: sinks.NewSyncMetricHandler(1024),
 		Engine:            "MergeTree",
 	}
 
-	// Setup tables
-	log.Println("[INFO]: Setting up Measurements table...")
-	err = clickhouseRec.SetupTables(context.Background())
+	err = chr.SetupTables()
 	if err != nil {
 		return nil, err
 	}
 
-	go clickhouseRec.HandleSyncMetric()
-
-	log.Println("[INFO]: Done!")
-	return clickhouseRec, nil
+	go chr.HandleSyncMetric()
+	return chr, nil
 }
 
-// Setup tables
-func (r *ClickHouseReceiver) SetupTables(ctx context.Context) error {
-
-	// Try creating JSON type if possible --
-	query := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS Measurements(dbname String,custom_tags Map(String, String),metric_def JSON,real_dbname String,system_identifier String,source_type String,data JSON,timestamp DateTime DEFAULT now(),PRIMARY KEY (dbname, timestamp)) ENGINE=%s`, r.Engine)
-	err := r.Conn.Exec(ctx, query)
+func (r *ClickHouseReceiver) SetupTables() error {
+	query := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS Measurements(dbname String, metric_name String, custom_tags Map(String, String), data JSON, timestamp DateTime DEFAULT now(), PRIMARY KEY (dbname, timestamp)) ENGINE=%s`, r.Engine)
+	err := r.Conn.Exec(context.TODO(), query)
 
 	if err != nil {
-		// String Query
-		log.Println("[INFO]: Unable to enforce JSON object. Will use string for storing JSON data")
-		query = fmt.Sprintf(`CREATE TABLE IF NOT EXISTS Measurements(dbname String,custom_tags Map(String, String),metric_def String,real_dbname String,system_identifier String,source_type String,data String,timestamp DateTime DEFAULT now(),PRIMARY KEY (dbname, timestamp)) ENGINE=%s`, r.Engine)
+		log.Println("[INFO]: Unable to enforce JSON object. Will use string for storing Measurements data")
+		query = fmt.Sprintf(`CREATE TABLE IF NOT EXISTS Measurements(dbname String, metric_name String, custom_tags Map(String, String), data String, timestamp DateTime DEFAULT now(),PRIMARY KEY (dbname, timestamp)) ENGINE=%s`, r.Engine)
 	}
 
-	err = r.Conn.Exec(ctx, query)
-	if err != nil {
-		return errors.New("failed to create Measurements table: " + err.Error())
-	}
-	return nil
+	err = r.Conn.Exec(context.TODO(), query)
+	return err
 }
 
-// Insert data
-func (r *ClickHouseReceiver) InsertMeasurements(data *api.MeasurementEnvelope, ctx context.Context) error {
-
-	// customTags, _ := json.Marshal(data.CustomTags)
-	metricDef, _ := json.Marshal(data.MetricDef)
-
-	batch, err := r.Conn.PrepareBatch(ctx, `
-		INSERT INTO Measurements (dbname, custom_tags, metric_def, real_dbname, system_identifier, source_type, data)
-		VALUES (?, ?, ?, ?, ?, ?, ?)`)
+func (r *ClickHouseReceiver) InsertMeasurements(ctx context.Context, data *pb.MeasurementEnvelope) error {
+	batch, err := r.Conn.PrepareBatch(ctx, `INSERT INTO Measurements (dbname, metric_name, custom_tags, data) VALUES (?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare batch: %v", err)
 	}
 
-	for _, measurement := range data.Data {
-		measurementJson, err := json.Marshal(measurement)
-		if err != nil {
-			msg := "unable to insert measurments"
-			log.Println("[ERROR]: " + msg)
-			log.Println(msg)
-		}
+	for _, measurement := range data.GetData() {
+		measurementJson := sinks.GetJson(measurement)
 
-		err = batch.Append(data.DBName, data.CustomTags, string(metricDef), data.RealDbname, data.SystemIdentifier, data.SourceType, string(measurementJson))
+		err = batch.Append(
+			data.GetDBName(), 
+			data.GetMetricName(),
+			data.GetCustomTags(),
+			measurementJson,
+		)
+
 		if err != nil {
 			msg := "unable to insert data - " + err.Error()
-			log.Println("[ERROR]: " + msg)
+			log.Println(msg)
 			return errors.New(msg)
 		}
 	}
-	err = batch.Send()
-	if err != nil {
-		return err
-	}
 
-	return nil
+	err = batch.Send()
+	return err
 }
 
-func (r *ClickHouseReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *string) error {
-	if err := sinks.IsValidMeasurement(msg); err != nil {
-		return  err
-	}
-
-	err := r.InsertMeasurements(msg, context.Background())
+func (r *ClickHouseReceiver) UpdateMeasurements(ctx context.Context, msg *pb.MeasurementEnvelope) (*pb.Reply, error) {
+	err := r.InsertMeasurements(ctx, msg)
 	if err != nil {
-		*logMsg = err.Error()
-		return err
+		return nil, err
 	}
-
 	log.Println("[INFO]: Inserted batch at : " + time.Now().String())
-	*logMsg = "[INFO]: Successfully inserted batch!"
-	return nil
+	return &pb.Reply{}, nil
 }

--- a/cmd/clickhouse_receiver/clickhouse_receiver_test.go
+++ b/cmd/clickhouse_receiver/clickhouse_receiver_test.go
@@ -3,210 +3,130 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"reflect"
 	"testing"
 	"time"
 
-	"github.com/cybertec-postgresql/pgwatch/v3/api"
+	"github.com/destrex271/pgwatch3_rpc_server/sinks"
+	"github.com/destrex271/pgwatch3_rpc_server/sinks/pb"
 	"github.com/stretchr/testify/assert"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func initContainer(ctx context.Context, user string, password string, dbname string) (testcontainers.Container, error) {
-
+func initContainer(ctx context.Context, User string, Password string, DBName string) (testcontainers.Container, error) {
 	req := testcontainers.ContainerRequest{
 		Image:        "clickhouse/clickhouse-server:24.7",
 		ExposedPorts: []string{"9000/tcp"},
 		WaitingFor:   wait.ForLog("Logging errors to").WithStartupTimeout(2 * time.Minute),
 		Env: map[string]string{
-			"CLICKHOUSE_DB":       dbname,
-			"CLICKHOUSE_USER":     user,
-			"CLICKHOUSE_PASSWORD": password,
+			"CLICKHOUSE_DB":       DBName,
+			"CLICKHOUSE_USER":     User,
+			"CLICKHOUSE_PASSWORD": Password,
 		},
 	}
 
-	// Create and start the container
 	clickhouseContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})
 
-	if err != nil {
-		return nil, err
-	}
-
 	// Delay to allow container to be ready
-	time.Sleep(5 * time.Second)
-
-	return clickhouseContainer, nil
+	time.Sleep(30 * time.Second)
+	return clickhouseContainer, err
 }
 
-func getMeasurementEnvelope() *api.MeasurementEnvelope {
-	measurement := make(map[string]any)
-	measurement["cpu"] = "0.001"
-	measurement["checkpointer"] = "1"
-	var measurements []map[string]any
-	measurements = append(measurements, measurement)
-
-	sql := make(map[int]string)
-	sql[12] = "select * from abc;"
-	metrics := &api.Metric{
-		SQLs:        sql,
-		InitSQL:     "select * from abc;",
-		NodeStatus:  "healthy",
-		StorageName: "teststore",
-		Description: "test metric",
+func GetTestMeasurementEnvelope() *pb.MeasurementEnvelope {
+	st, err := structpb.NewStruct(map[string]any{"key": "val"})
+	if err != nil {
+		panic(err)
 	}
-
-	return &api.MeasurementEnvelope{
+	measurements := []*structpb.Struct{st}
+	return &pb.MeasurementEnvelope{
 		DBName:           "test",
-		SourceType:       "test_source",
 		MetricName:       "testMetric",
-		CustomTags:       nil,
+		CustomTags: 	  map[string]string{"tagName": "tagValue"},
 		Data:             measurements,
-		MetricDef:        *metrics,
-		RealDbname:       "test",
-		SystemIdentifier: "Identifier",
 	}
 }
+
+var (
+	ctx context.Context = context.Background()
+	User string = "clickhouse"
+	Password string = "password"
+	DBName string = "testdb"
+	serverURI string
+)
+
+func TestMain(m *testing.M) {
+	container, err := initContainer(ctx, User, Password, DBName)
+	if err != nil {
+		panic(err)
+	}
+	defer func() { _ = container.Terminate(ctx) }()
+
+	mappedPort, err := container.MappedPort(ctx, "9000")
+	if err != nil {
+		panic(err)
+	}
+	serverURI = fmt.Sprintf("127.0.0.1:%d", mappedPort.Int())
+
+	exitCode := m.Run()
+	os.Exit(exitCode)
+}
+
+// Tests begin from here
 
 func TestGetConnection(t *testing.T) {
-
-	// Variables
-	ctx := context.Background()
-	user := "clickhouse"
-	password := "password"
-	dbname := "testdb"
-
-	// Create new container
-	container, err := initContainer(ctx, user, password, dbname)
-	if err != nil {
-		t.Fatal("[ERROR]: unable to create container. " + err.Error())
-	}
-	defer func() {
-		if err := container.Terminate(context.Background()); err != nil {
-			panic(err)
-		}
-	}()
-
-	mappedPort, err := container.MappedPort(context.Background(), "9000")
-	if err != nil {
-		t.Fatalf("Failed to get mapped port: %s", err)
-	}
-	serverUri := fmt.Sprintf("127.0.0.1:%d", mappedPort.Int())
-	conn, err := GetConnection(user, password, dbname, serverUri, true)
-
-	assert.Nil(t, err, "ecountered error while getting connection")
-	assert.NotNil(t, conn, "conn is null")
+	conn, err := GetConnection(User, Password, DBName, serverURI, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, conn)
 }
 
-func TestNewClickHouse(t *testing.T) {
-
-	// Variables
-	ctx := context.Background()
-	user := "clickhouse"
-	password := "password"
-	dbname := "testdb"
-
-	container, err := initContainer(context.Background(), user, password, dbname)
+func TestClickHouseReceiver(t *testing.T) {
+	container, err := initContainer(ctx, User, Password, DBName)
 	if err != nil {
-		t.Fatal("[ERROR]: unable to create container. " + err.Error())
+		panic(err)
 	}
-	defer func() {
-		if err := container.Terminate(context.Background()); err != nil {
-			panic(err)
+	defer func() { _ = container.Terminate(ctx) }()
+
+	mappedPort, err := container.MappedPort(ctx, "9000")
+	if err != nil {
+		panic(err)
+	}
+	serverURI = fmt.Sprintf("127.0.0.1:%d", mappedPort.Int())
+
+	recv, err := NewClickHouseReceiver(User, Password, DBName, serverURI, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, recv, "error creating clickhouse receiver")
+
+	msg := GetTestMeasurementEnvelope()
+
+	for cnt := range 5 {
+		_, err = recv.UpdateMeasurements(ctx, msg)
+		assert.NoError(t, err)
+
+		rows, err := recv.Conn.Query(ctx, "select * from Measurements;")
+		assert.NoError(t, err)
+
+		rowCount := 0
+		for rows.Next() {
+			var dbname, metric_name, data string
+			tags := make(map[string]string)
+			var timestamp time.Time
+			dataJson := sinks.GetJson(msg.GetData()[0])
+
+			err := rows.Scan(&dbname, &metric_name, &tags, &data, &timestamp)
+			assert.NoError(t, err, "Failed to scan row")
+			assert.Equal(t, dbname, msg.GetDBName())
+			assert.Equal(t, metric_name, msg.GetMetricName())
+			assert.True(t, reflect.DeepEqual(tags, msg.GetCustomTags()))
+			assert.Equal(t, data, dataJson)
+
+			rowCount++
 		}
-	}()
-
-	mappedPort, err := container.MappedPort(context.Background(), "9000")
-	if err != nil {
-		t.Fatalf("Failed to get mapped port: %s", err)
+		assert.Equalf(t, rowCount, cnt + 1, "Expected %v rows found %v", cnt + 1, rowCount)
 	}
-
-	uri := fmt.Sprintf("127.0.0.1:%d", mappedPort.Int())
-	recv, err := NewClickHouseReceiver(user, password, dbname, uri, true)
-
-	assert.Nil(t, err, "Encountered error while creating new receiver")
-	assert.NotNil(t, recv, "Receiver not created")
-
-	// Check if table was created/exists
-	_, err = recv.Conn.Query(ctx, "select * from Measurements;")
-
-	assert.Nil(t, err, "Measurements table not generated")
-}
-
-func TestInsertMeasurements(t *testing.T) {
-
-	// Variables
-	ctx := context.Background()
-	user := "clickhouse"
-	password := "password"
-	dbname := "testdb"
-
-	// Create Test container
-	container, err := initContainer(ctx, user, password, dbname)
-	if err != nil {
-		t.Fatal("[ERROR]: unable to create container. " + err.Error())
-	}
-	defer func() {
-		if err := container.Terminate(context.Background()); err != nil {
-			panic(err)
-		}
-	}()
-
-	// test data
-	data := getMeasurementEnvelope()
-
-	mappedPort, err := container.MappedPort(context.Background(), "9000")
-	if err != nil {
-		t.Fatalf("Failed to get mapped port: %s", err)
-	}
-
-	uri := fmt.Sprintf("127.0.0.1:%d", mappedPort.Int())
-	recv, err := NewClickHouseReceiver(user, password, dbname, uri, true)
-
-	assert.Nil(t, err, "Encountered error while creating new receiver")
-	assert.NotNil(t, recv, "Receiver not created")
-
-	// Insert Measurements
-	err = recv.InsertMeasurements(data, ctx)
-	assert.Nil(t, err, "error encountered while inserting measurements")
-}
-
-func TestUpdateMeasurements(t *testing.T) {
-	// Variables
-	ctx := context.Background()
-	user := "clickhouse"
-	password := "password"
-	dbname := "testdb"
-
-	// Create Test container
-	container, err := initContainer(ctx, user, password, dbname)
-	if err != nil {
-		t.Fatal("[ERROR]: unable to create container. " + err.Error())
-	}
-	defer func() {
-		if err := container.Terminate(context.Background()); err != nil {
-			panic(err)
-		}
-	}()
-
-	// test data
-	data := getMeasurementEnvelope()
-
-	mappedPort, err := container.MappedPort(context.Background(), "9000")
-	if err != nil {
-		t.Fatalf("Failed to get mapped port: %s", err)
-	}
-
-	uri := fmt.Sprintf("127.0.0.1:%d", mappedPort.Int())
-	recv, err := NewClickHouseReceiver(user, password, dbname, uri, true)
-
-	assert.Nil(t, err, "Encountered error while creating new receiver")
-	assert.NotNil(t, recv, "Receiver not created")
-
-	// Insert Measurements
-	msg := new(string)
-	err = recv.UpdateMeasurements(data, msg)
-	assert.Nil(t, err, "error encountered while updating measurements")
 }

--- a/cmd/clickhouse_receiver/main.go
+++ b/cmd/clickhouse_receiver/main.go
@@ -17,7 +17,6 @@ func main() {
 		return
 	}
 
-	var server sinks.Receiver
 	user := os.Getenv("user")
 	password := os.Getenv("password")
 	serverURI := os.Getenv("server")
@@ -27,7 +26,7 @@ func main() {
 		log.Fatal("[ERROR]: Unable to create Click house receiver: ", err)
 	}
 
-	if err = sinks.Listen(server, *port); err != nil {
+	if err = sinks.ListenAndServe(server, *port); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/duckdb_receiver/duckdb_receiver.go
+++ b/cmd/duckdb_receiver/duckdb_receiver.go
@@ -9,57 +9,60 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/cybertec-postgresql/pgwatch/v3/api"
 	"github.com/destrex271/pgwatch3_rpc_server/sinks"
+	"github.com/destrex271/pgwatch3_rpc_server/sinks/pb"
 )
 
 type DuckDBReceiver struct {
 	Ctx       context.Context
 	Conn      *sql.DB
-	DBName    string
+	dbPath    string
 	TableName string
 	sinks.SyncMetricHandler
 }
 
-func (dbr *DuckDBReceiver) initializeTable() {
+func (dbr *DuckDBReceiver) initializeTable() error {
 	// Allow only alphanumeric and underscores in table names
 	validateTableName := regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 	if !validateTableName.MatchString(dbr.TableName) {
-		log.Fatal("Invalid table name: potential SQL injection risk")
+		return fmt.Errorf("invalid table name: potential SQL injection risk")
 	}
 
-	createTableQuery := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (dbname VARCHAR, metric_name VARCHAR, data JSON, custom_tags JSON, metric_def JSON, timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (dbname, timestamp))`, dbr.TableName)
+	createTableQuery := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (dbname VARCHAR, metric_name VARCHAR, data JSON, custom_tags JSON, timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (dbname, timestamp))`, dbr.TableName)
 
 	_, err := dbr.Conn.Exec(createTableQuery)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	log.Print("Table successfully created")
+	return nil
 }
 
-func NewDBDuckReceiver(databaseName string, tableName string) (dbr *DuckDBReceiver, err error) {
+func NewDBDuckReceiver(dbPath string, tableName string) (dbr *DuckDBReceiver, err error) {
 	// close fatally if table isnt created, or if receiver isnt initailized properly
-	db, err := sql.Open("duckdb", databaseName)
+	db, err := sql.Open("duckdb", dbPath)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	dbr = &DuckDBReceiver{
 		Conn:      db,
-		DBName:    databaseName,
+		dbPath:    dbPath,
 		TableName: tableName,
 		Ctx:       context.Background(),
 	}
 
-	dbr.initializeTable()
-	go dbr.HandleSyncMetric()
+	err = dbr.initializeTable()
+	if err != nil {
+		return nil, err
+	}
 
+	go dbr.HandleSyncMetric()
 	return dbr, nil
 }
-func (r *DuckDBReceiver) InsertMeasurements(data *api.MeasurementEnvelope, ctx context.Context) error {
-	metricDef, _ := json.Marshal(data.MetricDef)
-	customTagsJSON, _ := json.Marshal(data.CustomTags)
-	// log.Println("Data:: ", data)
+
+func (r *DuckDBReceiver) InsertMeasurements(ctx context.Context, data *pb.MeasurementEnvelope) error {
+	customTagsJSON, _ := json.Marshal(data.GetCustomTags())
 
 	// use direct SQL approach - just use the existing connection with the standard insert statement
 	tx, err := r.Conn.BeginTx(ctx, nil)
@@ -69,7 +72,7 @@ func (r *DuckDBReceiver) InsertMeasurements(data *api.MeasurementEnvelope, ctx c
 	}
 
 	stmt, err := tx.Prepare("INSERT INTO " + r.TableName +
-		" (dbname, metric_name, data, custom_tags, metric_def, timestamp) VALUES (?, ?, ?, ?, ?, ?)")
+		" (dbname, metric_name, data, custom_tags, timestamp) VALUES (?, ?, ?, ?, ?)")
 	if err != nil {
 		log.Printf("error from preparing statement: %v", err)
 		_ = tx.Rollback()
@@ -77,22 +80,15 @@ func (r *DuckDBReceiver) InsertMeasurements(data *api.MeasurementEnvelope, ctx c
 	}
 	defer func() {_ = stmt.Close()}()
 
-	for _, measurement := range data.Data {
-		measurementJSON, err := json.Marshal(measurement)
-		if err != nil {
-			log.Printf("error from marshal measurement: %v", err)
-			_ = tx.Rollback()
-			return err
-		}
-
+	for _, measurement := range data.GetData() {
 		_, err = stmt.Exec(
-			data.DBName,
-			data.MetricName,
-			string(measurementJSON),
-			string(customTagsJSON),
-			string(metricDef),
+			data.GetDBName(),
+			data.GetMetricName(),
+			sinks.GetJson(measurement),
+			customTagsJSON,
 			time.Now(),
 		)
+
 		if err != nil {
 			log.Printf("error from insert: %v", err)
 			_ = tx.Rollback()
@@ -107,21 +103,15 @@ func (r *DuckDBReceiver) InsertMeasurements(data *api.MeasurementEnvelope, ctx c
 	return nil
 }
 
-func (r *DuckDBReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *string) error {
-	if err := sinks.IsValidMeasurement(msg); err != nil {
-		return  err
-	}
-
+func (r *DuckDBReceiver) UpdateMeasurements(ctx context.Context, msg *pb.MeasurementEnvelope) (*pb.Reply, error) {
 	log.Printf("Received measurement. DBName: '%s', MetricName: '%s', DataPoints: %d",
-		msg.DBName, msg.MetricName, len(msg.Data))
+		msg.GetDBName(), msg.GetMetricName(), len(msg.GetData()))
 
-	err := r.InsertMeasurements(msg, context.Background())
+	err := r.InsertMeasurements(ctx, msg)
 	if err != nil {
-		*logMsg = err.Error()
-		return err
+		return nil, err
 	}
 
 	log.Println("[INFO]: Inserted batch at : " + time.Now().String())
-	*logMsg = "[INFO]: Successfully inserted batch!"
-	return nil
+	return &pb.Reply{}, nil
 }

--- a/cmd/duckdb_receiver/duckdb_receiver_test.go
+++ b/cmd/duckdb_receiver/duckdb_receiver_test.go
@@ -2,110 +2,69 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/cybertec-postgresql/pgwatch/v3/api"
 	"github.com/destrex271/pgwatch3_rpc_server/sinks"
+	"github.com/destrex271/pgwatch3_rpc_server/sinks/pb"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func getMeasurementEnvelope() *api.MeasurementEnvelope {
-	measurement := make(map[string]any)
-	measurement["cpu"] = "0.001"
-	measurement["checkpointer"] = "1"
-	var measurements []map[string]any
-	measurements = append(measurements, measurement)
-
-	sql := make(map[int]string)
-	sql[12] = "select * from abc;"
-	metrics := &api.Metric{
-		SQLs:        sql,
-		InitSQL:     "select * from abc;",
-		NodeStatus:  "healthy",
-		StorageName: "teststore",
-		Description: "test metric",
+func GetTestMeasurementEnvelope() *pb.MeasurementEnvelope {
+	st, err := structpb.NewStruct(map[string]any{"key": "val"})
+	if err != nil {
+		panic(err)
 	}
-
-	return &api.MeasurementEnvelope{
+	measurements := []*structpb.Struct{st}
+	return &pb.MeasurementEnvelope{
 		DBName:           "test",
-		SourceType:       "test_source",
 		MetricName:       "testMetric",
-		CustomTags:       nil,
+		CustomTags: 	  map[string]string{"tagName": "tagValue"},
 		Data:             measurements,
-		MetricDef:        *metrics,
-		RealDbname:       "test",
-		SystemIdentifier: "Identifier",
 	}
 }
 
-const TEST_DATABASE_NAME string = "pgwatch_test.duckdb"
-
-var testDBPath string
+var dbPath string
 
 func TestMain(m *testing.M) {
 	currentDir, err := os.Getwd()
 	if err != nil {
-		fmt.Print("error in GetCwd: ", err)
-		os.Exit(1)
+		panic(err)
 	}
 	testDir := filepath.Join(currentDir, "test_tmp")
+
 	err = os.MkdirAll(testDir, 0755)
 	if err != nil {
-		fmt.Print("error in create test directory: ", err)
-		os.Exit(1)
+		panic(err)
 	}
+	dbPath = filepath.Join(testDir, "pgwatch_test.duckdb")
 
-	testDBPath = filepath.Join(testDir, TEST_DATABASE_NAME) // database path
-
-	// run the tests
-	code := m.Run()
-
-	// cleanup
-	_ = os.Remove(testDBPath)
-	_ = os.Remove(testDir)
-	os.Exit(code)
-}
-
-func setupTest() (*DuckDBReceiver, error) {
-	return NewDBDuckReceiver(testDBPath, "measurements")
+	exitCode := m.Run()
+	_ = os.RemoveAll(testDir)
+	os.Exit(exitCode)
 }
 
 func TestInitialize(t *testing.T) {
-	db, err := sql.Open("duckdb", testDBPath)
-	if err != nil {
-		t.Error(err)
-	}
-	dbr := &DuckDBReceiver{
-		Conn:              db,
-		DBName:            testDBPath,
-		TableName:         "measurements",
-		Ctx:               context.Background(),
-		SyncMetricHandler: sinks.NewSyncMetricHandler(1024),
-	}
-
-	dbr.initializeTable()
-	createTableQuery := "CREATE TABLE IF NOT EXISTS " + dbr.TableName + "(dbname VARCHAR, metric_name VARCHAR, data JSON, custom_tags JSON, metric_def JSON, timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (dbname, timestamp))"
-	_, err = dbr.Conn.Exec(createTableQuery)
-	if err != nil {
-		t.Error(err)
-	}
+	dbr, err := NewDBDuckReceiver(dbPath, "measurements")
+	assert.NoError(t, err, "error creating duckdb receiver")
 
 	// assert the table creation
-	rows, err := db.Query("SELECT name FROM sqlite_master WHERE type='table' AND name='measurements'")
-	assert.Nil(t, err, "could not to query tables")
+	rows, err := dbr.Conn.Query("SELECT name FROM sqlite_master WHERE type='table' AND name='measurements'")
+	assert.NoError(t, err, "could not to query tables")
 	defer func() {_ = rows.Close()}()
+
 	tableExists := rows.Next()
 	assert.True(t, tableExists, "Measurements table was not created")
 
 	// assert the structure
 	// note - pk and notnull are not INT types but bool types in duckdb
-	columns, err := db.Query("PRAGMA table_info(measurements)")
-	assert.Nil(t, err, "Failed to get table information")
+	columns, err := dbr.Conn.Query("PRAGMA table_info(measurements)")
+	assert.NoError(t, err, "Failed to get table information")
 	defer func() {_ = columns.Close()}()
+
 	columnNames := make(map[string]bool)
 	for columns.Next() {
 		var cid int
@@ -113,47 +72,51 @@ func TestInitialize(t *testing.T) {
 		var notnull bool
 		var dflt_value interface{}
 		var pk bool
+
 		err = columns.Scan(&cid, &name, &type_name, &notnull, &dflt_value, &pk)
-		assert.Nil(t, err, "Failed to scan column information")
+		assert.NoError(t, err, "Failed to scan column information")
 		columnNames[name] = true
 	}
+
 	// assert required columns exist (in this setting.)
-	requiredColumns := []string{"dbname", "metric_name", "data", "custom_tags", "metric_def", "timestamp"}
+	requiredColumns := []string{"dbname", "metric_name", "data", "custom_tags", "timestamp"}
 	for _, col := range requiredColumns {
 		assert.True(t, columnNames[col], fmt.Sprintf("Required column '%s' missing from table", col))
 	}
 }
 
 func TestUpdateMeasurements(t *testing.T) {
+	dbr, err := NewDBDuckReceiver(dbPath, "measurements")
+	assert.NoError(t, err, "error creating duckdb receiver")
 
-	dbr, err := setupTest()
-	if err != nil {
-		t.Error(err)
+	for cnt := range 5 {
+		// Call Update Measurements with dummy data
+		msg := GetTestMeasurementEnvelope()
+		_, err = dbr.UpdateMeasurements(context.Background(), msg)
+		assert.NoError(t, err)
+
+		// verify data was inserted
+		rows, err := dbr.Conn.Query("SELECT dbname, metric_name, data, custom_tags FROM measurements")
+		assert.NoError(t, err, "Failed to query database")
+		defer func(){_ = rows.Close()}()
+
+		rowCount := 0
+		for rows.Next() {
+			var dbname, metricName, customTags string
+			var data map[string]any
+			err := rows.Scan(&dbname, &metricName, &data, &customTags)
+			assert.NoError(t, err, "Failed to scan row")
+
+			customTagsJSON := sinks.GetJson(msg.GetCustomTags())
+			measurement := sinks.GetJson(msg.GetData()[0])
+
+			assert.Equal(t, msg.GetDBName(), dbname)
+			assert.Equal(t, msg.GetMetricName(), metricName)
+			assert.Equal(t, customTagsJSON, customTags)
+			assert.Equal(t, measurement, sinks.GetJson(data))
+
+			rowCount++
+		}
+		assert.Equalf(t, rowCount, cnt + 1, "Expected %v rows got %v", cnt + 1, rowCount)
 	}
-	defer func() {_ = dbr.Conn.Close()}()
-	// Call Update Measurements with dummy packet
-	msg := getMeasurementEnvelope()
-	logMsg := new(string)
-	err = dbr.UpdateMeasurements(msg, logMsg)
-	// time.Sleep(1 * time.Second)
-	assert.Nil(t, err, *logMsg)
-
-	// Check if root folder created for database
-	if _, err := os.Stat(testDBPath); err != nil {
-		assert.False(t, os.IsNotExist(err), "database was not created")
-	}
-
-	// verify data was inserted
-	rows, err := dbr.Conn.Query("SELECT dbname, metric_name FROM measurements")
-	assert.Nil(t, err, "Failed to query database")
-	defer func(){_ = rows.Close()}()
-
-	rowCount := 0
-	for rows.Next() {
-		var dbname, metricName string
-		err := rows.Scan(&dbname, &metricName)
-		assert.Nil(t, err, "Failed to scan row")
-		rowCount++
-	}
-	assert.Greater(t, rowCount, 0, "No rows found in database")
 }

--- a/cmd/duckdb_receiver/main.go
+++ b/cmd/duckdb_receiver/main.go
@@ -24,7 +24,7 @@ func main() {
 		log.Fatal("[ERROR]: Unable to create DuckDB receiver: ", err)
 	}
 
-	if err := sinks.Listen(server, *port); err != nil {
+	if err := sinks.ListenAndServe(server, *port); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/kafka_prod_receiver/kafka_prod_receiver.go
+++ b/cmd/kafka_prod_receiver/kafka_prod_receiver.go
@@ -3,13 +3,13 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"log"
 
-	"github.com/cybertec-postgresql/pgwatch/v3/api"
 	"github.com/destrex271/pgwatch3_rpc_server/sinks"
 	"github.com/destrex271/pgwatch3_rpc_server/sinks/pb"
 	"github.com/segmentio/kafka-go"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type KafkaProdReceiver struct {
@@ -29,7 +29,7 @@ func (r *KafkaProdReceiver) HandleSyncMetric() {
 		}
 
 		var err error
-		switch req.GetOperation() {
+		switch req.Operation {
 		case pb.SyncOp_AddOp:
 			err = r.CloseConnectionForDB(req.GetDBName())
 		case pb.SyncOp_DeleteOp:
@@ -93,47 +93,41 @@ func (r *KafkaProdReceiver) CloseConnectionForDB(dbName string) error {
 	return nil
 }
 
-func (r *KafkaProdReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *string) error {
-	if err := sinks.IsValidMeasurement(msg); err != nil {
-		return  err
-	}
-
+func (r *KafkaProdReceiver) UpdateMeasurements(ctx context.Context, msg *pb.MeasurementEnvelope) (*pb.Reply, error) {
 	// Get connection for database topic
-	conn := r.conn_regisrty[msg.DBName]
-
-	if conn == nil {
-		log.Println("[WARNING]: Connection does not exist for database " + msg.DBName)
+	DBName := msg.GetDBName()
+	conn, ok := r.conn_regisrty[DBName]
+	if !ok {
+		log.Println("[WARNING]: Connection does not exist for database " + DBName)
 		if r.auto_add {
-			log.Println("[INFO]: Adding database " + msg.DBName + " since Auto Add is enabled. You can disable it by restarting the sink with autoadd option as false")
-			err := r.AddTopicIfNotExists(msg.DBName)
+			log.Println("[INFO]: Adding database " + DBName + " since Auto Add is enabled. You can disable it by restarting the sink with autoadd option as false")
+			err := r.AddTopicIfNotExists(DBName)
 			if err != nil {
 				log.Println("[ERROR]: Unable to create new connection")
-				return err
+				return nil, err
 			}
-			conn = r.conn_regisrty[msg.DBName]
+			conn = r.conn_regisrty[DBName]
 		} else {
-			return errors.New("[FATAL] Auto Add not enabled. Please restart the sink with autoadd=true")
+			return nil, status.Error(codes.FailedPrecondition, "auto add not enabled. please restart the sink with autoadd=true")
 		}
 	}
 
 	// Convert MeasurementEnvelope struct to json and write it as message in kafka
 	json_data, err := json.Marshal(msg)
 	if err != nil {
-		*logMsg = "Unable to convert measurements data to json"
-		return err
+		log.Println("Unable to convert measurements data to json")
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	// conn.SetWriteDeadline(time.Now())
 	_, err = conn.WriteMessages(
 		kafka.Message{Value: json_data},
 	)
 
 	if err != nil {
-		*logMsg = "Failed to write messages!"
-		return err
+		log.Println("Failed to write messages!")
+		return nil, err
 	}
 
-	log.Println("[INFO]: Measurements Written to topic - ", msg.DBName)
-
-	return nil
+	log.Println("[INFO]: Measurements Written to topic - ", DBName)
+	return &pb.Reply{}, nil
 }

--- a/cmd/kafka_prod_receiver/kafka_prod_receiver_test.go
+++ b/cmd/kafka_prod_receiver/kafka_prod_receiver_test.go
@@ -2,16 +2,18 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/cybertec-postgresql/pgwatch/v3/api"
+	"github.com/destrex271/pgwatch3_rpc_server/sinks"
+	"github.com/destrex271/pgwatch3_rpc_server/sinks/pb"
 	"github.com/stretchr/testify/assert"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func initContainer(ctx context.Context) (testcontainers.Container, error) {
@@ -32,94 +34,57 @@ func initContainer(ctx context.Context) (testcontainers.Container, error) {
 	return container, nil
 }
 
-func getMeasurementEnvelope() *api.MeasurementEnvelope {
-	measurement := make(map[string]any)
-	measurement["cpu"] = "0.001"
-	measurement["checkpointer"] = "1"
-	var measurements []map[string]any
-	measurements = append(measurements, measurement)
-
-	sql := make(map[int]string)
-	sql[12] = "select * from abc;"
-	metrics := &api.Metric{
-		SQLs:        sql,
-		InitSQL:     "select * from abc;",
-		NodeStatus:  "healthy",
-		StorageName: "teststore",
-		Description: "test metric",
+func GetTestMeasurementEnvelope() *pb.MeasurementEnvelope {
+	st, err := structpb.NewStruct(map[string]any{"key": "val"})
+	if err != nil {
+		panic(err)
 	}
-
-	return &api.MeasurementEnvelope{
+	measurements := []*structpb.Struct{st}
+	return &pb.MeasurementEnvelope{
 		DBName:           "test",
-		SourceType:       "test_source",
 		MetricName:       "testMetric",
-		CustomTags:       nil,
 		Data:             measurements,
-		MetricDef:        *metrics,
-		RealDbname:       "test",
-		SystemIdentifier: "Identifier",
 	}
 }
 
-func TestNewKafkaProducer(t *testing.T) {
-	// Create new Producer
-	container, err := initContainer(context.Background())
-	defer func() {
-		t.Log("Terminating test container")
-		_ = container.Terminate(context.Background())
-	}()
+var container testcontainers.Container
+var err error
+var ctx = context.Background()
 
+func TestMain(m *testing.M) {
+	container, err = initContainer(ctx)
 	if err != nil {
-		t.Log("FAILING!")
-		t.Error(err)
-		t.Log(container.Host(context.Background()))
+		panic(err)
 	}
 
-	kpr, err := NewKafkaProducer("localhost:9092", nil, nil, true)
+	defer func() {
+		_ = container.Terminate(ctx)
+	}()
 
-	assert.Nil(t, err, "Error encountered while create new kafka producer")
-	assert.NotNil(t, kpr, "Kafka Producer created")
+	exitCode := m.Run()
+	os.Exit(exitCode)
 }
 
-func TestUpdateMeasurements(t *testing.T) {
-	// Create new Producer
-	container, err := initContainer(context.Background())
-	defer func() {
-		t.Log("Terminating test container...")
-		_ = container.Terminate(context.Background())
-	}()
+// Tests begin from here
 
-	if err != nil {
-		t.Fatal(err)
-	}
-
+func TestKafka_UpdateMeasurements(t *testing.T) {
 	kpr, err := NewKafkaProducer("localhost:9092", nil, nil, true)
+	assert.NoError(t, err, "Error encountered while creating kafka producer")
+	assert.NotNil(t, kpr, "Kafka Producer object is nil")
 
-	assert.Nil(t, err, "Error encountered while create new kafka producer")
-	assert.NotNil(t, kpr, "Kafka Producer created")
-
-	// Send dummy measurement to kafka topic
-	msg := getMeasurementEnvelope()
-	logMsg := new(string)
-	err = kpr.UpdateMeasurements(msg, logMsg)
-
-	// Check if connection was succesfully established
-	assert.Nil(t, err, "Error encoutered while adding new measurements")
+	msg := GetTestMeasurementEnvelope()
+	_, err = kpr.UpdateMeasurements(ctx, msg)
+	assert.NoError(t, err, "Error encountered while updating measurements")
 
 	// Try to consume data added to topic
 	cmd := []string{"timeout", "10s", "/opt/kafka/bin/kafka-console-consumer.sh", "--bootstrap-server", "localhost:9092", "--topic", "test", "--from-beginning"}
-	_, reader, err := container.Exec(context.Background(), cmd)
+	_, reader, err := container.Exec(ctx, cmd)
 	assert.NoError(t, err)
 
 	buf := new(strings.Builder)
 	_, err = io.Copy(buf, reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// See the logs from the command execution.
-	t.Log(buf)
-	msg_as_str, err := json.Marshal(msg)
 	assert.NoError(t, err)
-	assert.True(t, strings.Contains(buf.String(), string(msg_as_str)), "Unable to retrieve measurements from topic")
+
+	msg_as_str := sinks.GetJson(msg)
+	assert.True(t, strings.Contains(buf.String(), msg_as_str), "Unable to retrieve measurements from topic")
 }

--- a/cmd/kafka_prod_receiver/kafka_prod_receiver_test.go
+++ b/cmd/kafka_prod_receiver/kafka_prod_receiver_test.go
@@ -104,18 +104,18 @@ func TestKafka_SyncMetricHandler(t *testing.T) {
 	require.NotNil(t, kpr, "Kafka Producer object is nil")
 
 	req := GetTestRPCSyncRequest()
-	
-	kpr.SyncMetric(ctx, req)
-	// give some time for handler routine
-	time.Sleep(time.Second)
+	_, err = kpr.SyncMetric(ctx, req)
+	assert.NoError(t, err)
+	time.Sleep(time.Second) // give some time handler
+
 	_, exists := kpr.conn_regisrty[req.GetDBName()]
 	assert.True(t, exists)
 
 	req.Operation = pb.SyncOp_DeleteOp
+	_, err = kpr.SyncMetric(ctx, req)
+	assert.NoError(t, err)
+	time.Sleep(time.Second) // give some time handler
 
-	kpr.SyncMetric(ctx, req)
-	// give some time for handler routine
-	time.Sleep(time.Second)
 	_, exists = kpr.conn_regisrty[req.GetDBName()]
 	assert.False(t, exists)
 }

--- a/cmd/kafka_prod_receiver/main.go
+++ b/cmd/kafka_prod_receiver/main.go
@@ -18,13 +18,12 @@ func main() {
 		return
 	}
 
-	var server sinks.Receiver
 	server, err := NewKafkaProducer(*kafkaHost, nil, nil, *autoadd)
 	if err != nil {
 		log.Println("[ERROR]: Unable to create Kafka Producer ", err)
 	}
 
-	if err := sinks.Listen(server, *port); err != nil {
+	if err := sinks.ListenAndServe(server, *port); err != nil {
 		log.Fatal(err)
 	}	
 }

--- a/cmd/llama_receiver/llama_receiver.go
+++ b/cmd/llama_receiver/llama_receiver.go
@@ -121,7 +121,7 @@ func (r *LLamaReceiver) HandleSyncMetric() {
 		case pb.SyncOp_AddOp:
 			_, err = conn.Exec(r.Ctx, `INSERT INTO db(dbname) VALUES($1)`, req.GetDBName())
 		case pb.SyncOp_DeleteOp:
-			_, err = conn.Exec(r.Ctx, `DELETE FROM db WHERE dbanme=$1 CASCADE;`, req.GetDBName())
+			_, err = conn.Exec(r.Ctx, `DELETE FROM db WHERE dbname=$1;`, req.GetDBName())
 		}
 
 		if err != nil {
@@ -148,7 +148,7 @@ func (r *LLamaReceiver) SetupTables() error {
 		data JSONB,
 		metric_name TEXT,
 		database_id SERIAL,
-		FOREIGN KEY (database_id) REFERENCES db(id)
+		FOREIGN KEY (database_id) REFERENCES db(id) ON DELETE CASCADE
 	);`)
 	if err != nil {
 		log.Println("[ERROR]: unable to create Measurement table : " + err.Error())
@@ -159,7 +159,7 @@ func (r *LLamaReceiver) SetupTables() error {
 		insight_data TEXT, 
 		database_id BIGSERIAL, 
 		created_at TIMESTAMP NOT NULL DEFAULT(NOW() AT TIME ZONE 'UTC'),
-		FOREIGN KEY (database_id) REFERENCES db(id) 
+		FOREIGN KEY (database_id) REFERENCES db(id) ON DELETE CASCADE
 	)`)
 	if err != nil {
 		log.Println("[ERROR]: unable to create Insigths table : " + err.Error())

--- a/cmd/llama_receiver/llama_receiver.go
+++ b/cmd/llama_receiver/llama_receiver.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cybertec-postgresql/pgwatch/v3/api"
 	"github.com/destrex271/pgwatch3_rpc_server/sinks"
 	"github.com/destrex271/pgwatch3_rpc_server/sinks/pb"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -41,7 +40,7 @@ type LLamaReceiver struct {
 	Ctx       context.Context
 	ServerURI string
 	ConnPool  *pgxpool.Pool
-	MsmtBatch []*api.MeasurementEnvelope
+	MsmtBatch []*pb.MeasurementEnvelope
 	BatchSize int
 	mu sync.Mutex
 	MsCount   int
@@ -84,7 +83,7 @@ func NewLLamaReceiver(LLamaServerURI string, pgURI string, ctx context.Context, 
 		Ctx:               ctx,
 		ServerURI:         LLamaServerURI,
 		ConnPool:          pool,
-		MsmtBatch:         make([]*api.MeasurementEnvelope, 0, batchSize),
+		MsmtBatch:         make([]*pb.MeasurementEnvelope, 0, batchSize),
 		BatchSize:         batchSize,
 		SyncMetricHandler: sinks.NewSyncMetricHandler(1024),
 		MsCount:           0,
@@ -118,7 +117,7 @@ func (r *LLamaReceiver) HandleSyncMetric() {
 		}
 		defer conn.Release()
 
-		switch req.GetOperation() {
+		switch req.Operation {
 		case pb.SyncOp_AddOp:
 			_, err = conn.Exec(r.Ctx, `INSERT INTO db(dbname) VALUES($1)`, req.GetDBName())
 		case pb.SyncOp_DeleteOp:
@@ -170,7 +169,7 @@ func (r *LLamaReceiver) SetupTables() error {
 	return nil
 }
 
-func (r *LLamaReceiver) AddMeasurements(msg *api.MeasurementEnvelope) error {
+func (r *LLamaReceiver) AddMeasurements(msg *pb.MeasurementEnvelope) error {
 	conn, err := r.ConnPool.Acquire(r.Ctx)
 	if err != nil {
 		return errors.New("unable to acquire new connection")
@@ -179,32 +178,27 @@ func (r *LLamaReceiver) AddMeasurements(msg *api.MeasurementEnvelope) error {
 
 	var id int
 	// Try to fetch id
-	err = conn.QueryRow(r.Ctx, `SELECT id FROM db WHERE dbname=$1`, msg.DBName).Scan(&id)
+	err = conn.QueryRow(r.Ctx, `SELECT id FROM db WHERE dbname=$1`, msg.GetDBName()).Scan(&id)
 	if err != nil {
 		if err.Error() != "no rows in result set" {
 			return err
 		}
 		// if not found, add database to table
-		_, err := conn.Exec(r.Ctx, `INSERT INTO db(dbname) VALUES($1)`, msg.DBName)
+		_, err := conn.Exec(r.Ctx, `INSERT INTO db(dbname) VALUES($1)`, msg.GetDBName())
 		if err != nil {
 			return err
 		}
 
 		// Get new id
-		err = conn.QueryRow(r.Ctx, `SELECT id FROM db WHERE dbname=$1`, msg.DBName).Scan(&id)
+		err = conn.QueryRow(r.Ctx, `SELECT id FROM db WHERE dbname=$1`, msg.GetDBName()).Scan(&id)
 		if err != nil {
 			return err
 		}
 	}
 
-	// Convert measurement to json
-	jsonData, err := json.Marshal(msg.Data)
-	if err != nil {
-		return err
-	}
-
-	// insert measurements with current timestamp(default) into table Measurement
-	_, err = conn.Exec(r.Ctx, `INSERT INTO measurements(data, database_id, metric_name) VALUES($1, $2, $3)`, string(jsonData), id, msg.MetricName)
+	// insert measurements with current timestamp(default) into table measurements
+	jsonData := sinks.GetJson(msg.GetData())
+	_, err = conn.Exec(r.Ctx, `INSERT INTO measurements(data, database_id, metric_name) VALUES($1, $2, $3)`, jsonData, id, msg.GetMetricName())
 	if err != nil {
 		return err
 	}
@@ -290,8 +284,8 @@ func (r *LLamaReceiver) AddInsights(dbid int, insights string) error {
 	return nil
 }
 
-func (r *LLamaReceiver) GenerateInsights(msg *api.MeasurementEnvelope) error {
-	final_msg, err := r.PreparePrompt(msg.DBName, msg.MetricName)
+func (r *LLamaReceiver) GenerateInsights(msg *pb.MeasurementEnvelope) error {
+	final_msg, err := r.PreparePrompt(msg.GetDBName(), msg.GetMetricName())
 	if err != nil {
 		return err
 	}
@@ -332,7 +326,7 @@ func (r *LLamaReceiver) GenerateInsights(msg *api.MeasurementEnvelope) error {
 	}
 
 	<-done // wait for the chat to complete
-	id, err := r.GetDBID(msg.DBName)
+	id, err := r.GetDBID(msg.GetDBName())
 	if err != nil {
 		return errors.New("unable to find database in records")
 	}
@@ -345,15 +339,11 @@ func (r *LLamaReceiver) GenerateInsights(msg *api.MeasurementEnvelope) error {
 	return nil
 }
 
-func (r *LLamaReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *string) error {
-	if err := sinks.IsValidMeasurement(msg); err != nil {
-		return  err
-	}
-
+func (r *LLamaReceiver) UpdateMeasurements(ctx context.Context, msg *pb.MeasurementEnvelope) (*pb.Reply, error) {
 	// store measurement in pg database
 	err := r.AddMeasurements(msg)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	log.Println("[INFO]: Inserted entry into database")
@@ -368,7 +358,7 @@ func (r *LLamaReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg 
 		// Generate insights for measurements of batch set
 		for _, val := range r.MsmtBatch {
 			r.InsightsGenerationWg.Add(1)
-			go func(val *api.MeasurementEnvelope) {
+			go func(val *pb.MeasurementEnvelope) {
 				defer r.InsightsGenerationWg.Done()
 				err = r.GenerateInsights(val)
 				if err != nil {
@@ -383,5 +373,5 @@ func (r *LLamaReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg 
 	}
 	r.mu.Unlock()
 
-	return nil
+	return &pb.Reply{}, nil
 }

--- a/cmd/llama_receiver/llama_receiver_test.go
+++ b/cmd/llama_receiver/llama_receiver_test.go
@@ -2,17 +2,19 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
-	"math/rand"
+	"os"
 	"testing"
 	"time"
 
-	"github.com/cybertec-postgresql/pgwatch/v3/api"
+	"github.com/destrex271/pgwatch3_rpc_server/sinks/pb"
 	"github.com/stretchr/testify/assert"
 	"github.com/testcontainers/testcontainers-go"
 	tcollama "github.com/testcontainers/testcontainers-go/modules/ollama"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 const new_image = "tinyllama_image"
@@ -60,297 +62,118 @@ func initPostgresContainer(ctx context.Context) (*postgres.PostgresContainer, er
 	return postgresContainer, nil
 }
 
-func getMeasurementEnvelope() *api.MeasurementEnvelope {
-	measurement := make(map[string]any)
-	measurement["cpu"] = rand.Float64() * 1
-	measurement["checkpointer"] = rand.Intn(100)
-	var measurements []map[string]any
-	measurements = append(measurements, measurement)
-
-	sql := make(map[int]string)
-	sql[12] = "select * from abc;"
-	metrics := &api.Metric{
-		SQLs:        sql,
-		InitSQL:     "select * from abc;",
-		NodeStatus:  "healthy",
-		StorageName: "teststore",
-		Description: "test metric",
+func GetTestMeasurementEnvelope() *pb.MeasurementEnvelope {
+	st, err := structpb.NewStruct(map[string]any{"key": "val"})
+	if err != nil {
+		panic(err)
 	}
-
-	return &api.MeasurementEnvelope{
+	measurements := []*structpb.Struct{st}
+	return &pb.MeasurementEnvelope{
 		DBName:           "test",
-		SourceType:       "test_source",
-		MetricName:       "health",
-		CustomTags:       nil,
+		MetricName:       "testMetric",
+		CustomTags: 	  map[string]string{"tagName": "tagValue"},
 		Data:             measurements,
-		MetricDef:        *metrics,
-		RealDbname:       "test",
-		SystemIdentifier: "Identifier",
 	}
 }
 
-func TestNewLLamaReceiver(t *testing.T) {
-	ctx := context.Background()
+func GetTestRPCSyncRequest() *pb.SyncReq {
+	return &pb.SyncReq{
+		DBName:     "test_db",
+		MetricName: "test_metric",
+		Operation:  pb.SyncOp_AddOp,
+	}
+}
 
+var (
+	ctx context.Context = context.Background()
+	llamaConnectionStr string
+	pgConnectionStr string
+)
+
+func TestMain(m *testing.M) {
 	ollamaContainer, err := initOllamaContainer(ctx)
 	if err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
 
 	postgresContainer, err := initPostgresContainer(ctx)
 	if err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
 
 	defer func() {
-		if err := ollamaContainer.Terminate(ctx); err != nil {
-			log.Printf("failed to terminate container: %s", err)
-		}
-		if err := postgresContainer.Terminate(ctx); err != nil {
-			log.Printf("failed to terminate container: %s", err)
-		}
+		_ = ollamaContainer.Terminate(ctx)
+		_ = postgresContainer.Terminate(ctx)
 	}()
 
-	// Create new receiver
-	connectionStr, err := ollamaContainer.ConnectionString(ctx)
+	// wait a little to ensure full startup of containers
+	time.Sleep(5 * time.Second)
+
+	llamaConnectionStr, err = ollamaContainer.ConnectionString(ctx)
 	if err != nil {
-		log.Println("Unable to get ollama connection string")
-		t.Fatal(err)
+		panic(err)
 	}
 
-	pgConnectionStr, err := postgresContainer.ConnectionString(ctx)
+	pgConnectionStr, err = postgresContainer.ConnectionString(ctx)
 	if err != nil {
-		log.Println("Unable to get Postgres connection string")
-		t.Fatal(err)
+		panic(err)
 	}
 
-	recv, err := NewLLamaReceiver(connectionStr, pgConnectionStr, ctx, 10)
-
-	assert.NotNil(t, recv, "Receiver object is nil")
-	assert.Nil(t, err, "Error encountered while creating receiver")
+	exitCode := m.Run()
+	os.Exit(exitCode)
 }
 
-func TestSetupTables(t *testing.T) {
-	ctx := context.Background()
+// Tests start from here
 
-	ollamaContainer, err := initOllamaContainer(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	postgresContainer, err := initPostgresContainer(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer func() {
-		if err := ollamaContainer.Terminate(ctx); err != nil {
-			log.Printf("failed to terminate container: %s", err)
-		}
-		if err := postgresContainer.Terminate(ctx); err != nil {
-			log.Printf("failed to terminate container: %s", err)
-		}
-	}()
-
-	// Create new receiver
-	connectionStr, err := ollamaContainer.ConnectionString(ctx)
-	if err != nil {
-		log.Println("Unable to get ollama connection string")
-		t.Fatal(err)
-	}
-
-	pgConnectionStr, err := postgresContainer.ConnectionString(ctx)
-	if err != nil {
-		log.Println("Unable to get Postgres connection string")
-		t.Fatal(err)
-	}
-
-	recv, err := NewLLamaReceiver(connectionStr, pgConnectionStr, ctx, 10)
-
+func TestLLamaReceiver(t *testing.T) {
+	var err error
+	recv, err := NewLLamaReceiver(llamaConnectionStr, pgConnectionStr, ctx, 1)
 	assert.NotNil(t, recv, "Receiver object is nil")
-	assert.Nil(t, err, "Error encountered while creating receiver")
+	assert.NoError(t, err, "Error encountered while creating receiver")
 
-	// obtain db conneciton
 	conn, err := recv.ConnPool.Acquire(recv.Ctx)
+	assert.NoError(t, err, "error encountered while acquiring new connection")
+	assert.NotNil(t, conn, "connection obtained is nil")
 
-	assert.Nil(t, err, "error encountered while acquiring new connection")
-	assert.NotNil(t, conn, "connection obtained in nil")
-	defer conn.Release()
+	msg := GetTestMeasurementEnvelope()
 
-	// Call setup tables function
-	err = recv.SetupTables()
-	assert.Nil(t, err, "error encountered while setting up tables")
+	t.Run("check setuped tables", func(t *testing.T) {
+		dbs := [3]string{"db", "measurements", "insights"}
+		var doesExist bool
+		for _, db := range dbs {
+			query := fmt.Sprintf("SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = '%s');", db)
 
-	// Check postgres for DB table
-	var doesExist bool
-	err = conn.QueryRow(recv.Ctx, `SELECT EXISTS (
-		SELECT FROM information_schema.tables 
-		WHERE  table_name   = 'db'
-    );`).Scan(&doesExist)
-
-	assert.Nil(t, err, "error encountered while querying table")
-	assert.True(t, doesExist, "table DB does not exist")
-
-	// Check postgres for Measurement table
-	err = conn.QueryRow(recv.Ctx, `SELECT EXISTS (
-		SELECT FROM information_schema.tables 
-		WHERE  table_name   = 'measurements'
-    );`).Scan(&doesExist)
-
-	assert.Nil(t, err, "error encountered while querying table")
-	assert.True(t, doesExist, "table Measurements does not exist")
-
-	// Check postgres for Insights
-	err = conn.QueryRow(recv.Ctx, `SELECT EXISTS (
-		SELECT FROM information_schema.tables 
-		WHERE  table_name   = 'insights'
-    );`).Scan(&doesExist)
-
-	assert.Nil(t, err, "error encountered while querying table")
-	assert.True(t, doesExist, "table insights does not exist")
-}
-
-func TestUpdateMeasurements(t *testing.T) {
-	ctx := context.Background()
-
-	ollamaContainer, err := initOllamaContainer(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	postgresContainer, err := initPostgresContainer(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer func() {
-		if err := ollamaContainer.Terminate(ctx); err != nil {
-			log.Printf("failed to terminate container: %s", err)
+			err := conn.QueryRow(recv.Ctx, query).Scan(&doesExist)
+			assert.NoError(t, err, "error querying information_schema table")
+			assert.Truef(t, doesExist, "table %s does not exist", db)
 		}
-		if err := postgresContainer.Terminate(ctx); err != nil {
-			log.Printf("failed to terminate container: %s", err)
+	})
+
+	t.Run("Update Measurements", func(t *testing.T) {
+		_, err := recv.UpdateMeasurements(ctx, msg)
+		assert.NoError(t, err, "error encountered while updating measurements")
+
+		// Check insights table for new entry
+		newInsightsCount := 0
+		recv.InsightsGenerationWg.Wait()
+		err = conn.QueryRow(recv.Ctx, "SELECT COUNT(*) FROM insights;").Scan(&newInsightsCount)
+		
+		assert.NoError(t, err)
+		assert.Equal(t, newInsightsCount, 1, "No new entries inserted in insights table")
+	})
+
+	t.Run("Update Measurements Multiple", func(t *testing.T) {
+		for range 10 {
+			_, err := recv.UpdateMeasurements(ctx, msg)
+			assert.NoError(t, err, "error encountered while updating measurements")
 		}
-	}()
 
-	// Create new receiver
-	connectionStr, err := ollamaContainer.ConnectionString(ctx)
-	if err != nil {
-		log.Println("Unable to get ollama connection string")
-		t.Fatal(err)
-	}
+		newInsightsCount := 0
+		recv.InsightsGenerationWg.Wait()
+		err := conn.QueryRow(recv.Ctx, "SELECT COUNT(*) FROM insights;").Scan(&newInsightsCount)
+		
+		assert.NoError(t, err)
+		assert.Greater(t, newInsightsCount, 1, "No new entries inserted in insights table")
+	})
 
-	pgConnectionStr, err := postgresContainer.ConnectionString(ctx)
-	if err != nil {
-		log.Println("Unable to get Postgres connection string")
-		t.Fatal(err)
-	}
-
-	recv, err := NewLLamaReceiver(connectionStr, pgConnectionStr, ctx, 1)
-
-	assert.NotNil(t, recv, "Receiver object is nil")
-	assert.Nil(t, err, "Error encountered while creating receiver")
-
-	// obtain db conneciton
-	conn, err := recv.ConnPool.Acquire(recv.Ctx)
-
-	assert.Nil(t, err, "error encountered while acquiring new connection")
-	assert.NotNil(t, conn, "connection obtained in nil")
-	defer conn.Release()
-
-	// Get current number of insights in database
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Send Update Measurements
-	msg := getMeasurementEnvelope()
-	logMsg := new(string)
-
-	err = recv.UpdateMeasurements(msg, logMsg)
-
-	assert.Nil(t, err, "error encountered while updating measurements")
-
-	// Check insights table for new entry
-	newInsightsCount := 0
-	recv.InsightsGenerationWg.Wait()
-	err = conn.QueryRow(recv.Ctx, "SELECT COUNT(*) FROM insights;").Scan(&newInsightsCount)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(t, newInsightsCount, 1, "No new entries inserted in insights table")
-}
-
-// Insert multiple records
-func TestUpdateMeasurements_Multiple(t *testing.T) {
-	ctx := context.Background()
-
-	ollamaContainer, err := initOllamaContainer(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	postgresContainer, err := initPostgresContainer(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer func() {
-		if err := ollamaContainer.Terminate(ctx); err != nil {
-			log.Printf("failed to terminate container: %s", err)
-		}
-		if err := postgresContainer.Terminate(ctx); err != nil {
-			log.Printf("failed to terminate container: %s", err)
-		}
-	}()
-
-	// Create new receiver
-	connectionStr, err := ollamaContainer.ConnectionString(ctx)
-	if err != nil {
-		log.Println("Unable to get ollama connection string")
-		t.Fatal(err)
-	}
-
-	pgConnectionStr, err := postgresContainer.ConnectionString(ctx)
-	if err != nil {
-		log.Println("Unable to get Postgres connection string")
-		t.Fatal(err)
-	}
-
-	recv, err := NewLLamaReceiver(connectionStr, pgConnectionStr, ctx, 1)
-
-	assert.NotNil(t, recv, "Receiver object is nil")
-	assert.Nil(t, err, "Error encountered while creating receiver")
-
-	// obtain db conneciton
-	conn, err := recv.ConnPool.Acquire(recv.Ctx)
-
-	assert.Nil(t, err, "error encountered while acquiring new connection")
-	assert.NotNil(t, conn, "connection obtained in nil")
-	defer conn.Release()
-
-	// Get current number of insights in database
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Send Update Measurements
-	msg := getMeasurementEnvelope()
-	logMsg := new(string)
-
-	oldCount := 0
-	for range 10 {
-		err = recv.UpdateMeasurements(msg, logMsg)
-		assert.Nil(t, err, "error encountered while updating measurements")
-	}
-
-	newInsightsCount := 0
-	t.Log("waiting.....")
-	recv.InsightsGenerationWg.Wait()
-	t.Log("waiting done")
-	err = conn.QueryRow(recv.Ctx, "SELECT COUNT(*) FROM insights;").Scan(&newInsightsCount)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Greater(t, newInsightsCount, oldCount, "No new entries inserted in insights table")
 }

--- a/cmd/llama_receiver/llama_receiver_test.go
+++ b/cmd/llama_receiver/llama_receiver_test.go
@@ -176,4 +176,26 @@ func TestLLamaReceiver(t *testing.T) {
 		assert.Greater(t, newInsightsCount, 1, "No new entries inserted in insights table")
 	})
 
+	t.Run("LLama SyncMetricHandler", func(t *testing.T) {
+		var exists bool
+		req := GetTestRPCSyncRequest()
+		query := fmt.Sprintf("SELECT EXISTS (SELECT * FROM db WHERE dbname = '%s')", req.GetDBName())
+
+		recv.SyncMetric(ctx, req)
+		// give some time for handler routine
+		time.Sleep(time.Second)
+
+		err := conn.QueryRow(ctx, query).Scan(&exists)
+		assert.NoError(t, err)
+		assert.True(t, exists)
+
+		req.Operation = pb.SyncOp_DeleteOp
+		recv.SyncMetric(ctx, req)
+		// give some time for handler routine
+		time.Sleep(time.Second)
+
+		err = conn.QueryRow(ctx, query).Scan(&exists)
+		assert.NoError(t, err)
+		assert.False(t, exists)
+	})
 }

--- a/cmd/llama_receiver/llama_receiver_test.go
+++ b/cmd/llama_receiver/llama_receiver_test.go
@@ -181,18 +181,18 @@ func TestLLamaReceiver(t *testing.T) {
 		req := GetTestRPCSyncRequest()
 		query := fmt.Sprintf("SELECT EXISTS (SELECT * FROM db WHERE dbname = '%s')", req.GetDBName())
 
-		recv.SyncMetric(ctx, req)
-		// give some time for handler routine
-		time.Sleep(time.Second)
+		_, err = recv.SyncMetric(ctx, req)
+		assert.NoError(t, err)
+		time.Sleep(time.Second) // give some time for handler
 
 		err := conn.QueryRow(ctx, query).Scan(&exists)
 		assert.NoError(t, err)
 		assert.True(t, exists)
 
 		req.Operation = pb.SyncOp_DeleteOp
-		recv.SyncMetric(ctx, req)
-		// give some time for handler routine
-		time.Sleep(time.Second)
+		_, err = recv.SyncMetric(ctx, req)
+		assert.NoError(t, err)
+		time.Sleep(time.Second) // give some time for handler
 
 		err = conn.QueryRow(ctx, query).Scan(&exists)
 		assert.NoError(t, err)

--- a/cmd/llama_receiver/main.go
+++ b/cmd/llama_receiver/main.go
@@ -23,7 +23,6 @@ func main() {
 		return
 	}
 
-	var server sinks.Receiver
 	server, err := NewLLamaReceiver(*serverURI, *pgURI, context.Background(), *batchSize)
 	if err != nil {
 		log.Fatal(err)
@@ -43,7 +42,7 @@ func main() {
 		}()
 	}
 
-	if err := sinks.Listen(server, *port); err != nil {
+	if err := sinks.ListenAndServe(server, *port); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/pinot_receiver/config/schema.json
+++ b/cmd/pinot_receiver/config/schema.json
@@ -20,11 +20,6 @@
       "name": "custom_tags",
       "dataType": "STRING",
       "defaultNullValue": "{}"
-    },
-    {
-      "name": "metric_def",
-      "dataType": "STRING",
-      "defaultNullValue": "{}"
     }
   ],
   "metricFieldSpecs": [],

--- a/cmd/pinot_receiver/main.go
+++ b/cmd/pinot_receiver/main.go
@@ -84,7 +84,7 @@ func main() {
 
 	log.Println("[INFO]: Pinot Receiver Initialized")
 
-	if err := sinks.Listen(server, *port); err != nil {
+	if err := sinks.ListenAndServe(server, *port); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/pinot_receiver/pinot_receiver.go
+++ b/cmd/pinot_receiver/pinot_receiver.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,8 +15,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/cybertec-postgresql/pgwatch/v3/api"
 	"github.com/destrex271/pgwatch3_rpc_server/sinks"
+	"github.com/destrex271/pgwatch3_rpc_server/sinks/pb"
 )
 
 // PinotReceiver handles sending metrics to a Pinot cluster
@@ -27,7 +28,6 @@ type PinotReceiver struct {
 	sinks.SyncMetricHandler
 }
 
-// NewPinotReceiver creates a new Pinot receiver
 func NewPinotReceiver(controllerURL, tableName, configDir string) (*PinotReceiver, error) {
 	receiver := &PinotReceiver{
 		ControllerURL:     controllerURL,
@@ -206,14 +206,13 @@ func (r *PinotReceiver) createTable(tableConfigPath string) error {
 	return nil
 }
 
-func (r *PinotReceiver) insertData(dbName, metricName string, data, customTags, metricDef []byte) error {
+func (r *PinotReceiver) insertData(dbName, metricName, data, customTags string) error {
 	// Format data for Pinot ingestion
 	ingestionData := map[string]interface{}{
 		"dbname":      dbName,
 		"metric_name": metricName,
-		"data":        string(data),
-		"custom_tags": string(customTags),
-		"metric_def":  string(metricDef),
+		"data":        data,
+		"custom_tags": customTags,
 		"timestamp":   time.Now().UnixMilli(),
 	}
 
@@ -295,34 +294,24 @@ func (r *PinotReceiver) insertData(dbName, metricName string, data, customTags, 
 	return nil
 }
 
-// UpdateMeasurements implements the Receiver interface
-func (r *PinotReceiver) UpdateMeasurements(msg *api.MeasurementEnvelope, logMsg *string) error {
-	if err := sinks.IsValidMeasurement(msg); err != nil {
-		return  err
-	}
+func (r *PinotReceiver) UpdateMeasurements(ctx context.Context, msg *pb.MeasurementEnvelope) (*pb.Reply, error) {
+	customTagsJSON := sinks.GetJson(msg.GetCustomTags())
 
-	log.Printf("Received measurement. DBName: '%s', MetricName: '%s', DataPoints: %d",
-		msg.DBName, msg.MetricName, len(msg.Data))
-
-	// Process each measurement
-	metricDefJSON, _ := json.Marshal(msg.MetricDef)
-	customTagsJSON, _ := json.Marshal(msg.CustomTags)
-
-	for _, measurement := range msg.Data {
-		measurementJSON, err := json.Marshal(measurement)
-		if err != nil {
-			*logMsg = fmt.Sprintf("error marshalling measurement: %v", err)
-			return errors.New(*logMsg)
+	reply := &pb.Reply{}
+	for _, measurement := range msg.GetData() {
+		if ctx.Err() != nil {
+			reply.Logmsg = "context cancelled, stopping writer..."
+			return reply, nil
 		}
 
-		err = r.insertData(msg.DBName, msg.MetricName, measurementJSON, customTagsJSON, metricDefJSON)
+		measurementJSON := sinks.GetJson(measurement)
+		err := r.insertData(msg.GetDBName(), msg.GetMetricName(), measurementJSON, customTagsJSON)
 		if err != nil {
-			*logMsg = fmt.Sprintf("error inserting data: %v", err)
-			return errors.New(*logMsg)
+			logMsg := fmt.Sprintf("error inserting data: %v", err)
+			return nil, errors.New(logMsg)
 		}
 	}
+	log.Println("[INFO]: Successfully inserted batch at : " + time.Now().String())
 
-	log.Println("[INFO]: Inserted batch at : " + time.Now().String())
-	*logMsg = "[INFO]: Successfully inserted batch!"
-	return nil
+	return reply, nil
 }

--- a/cmd/pinot_receiver/pinot_receiver_test.go
+++ b/cmd/pinot_receiver/pinot_receiver_test.go
@@ -1,15 +1,17 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/cybertec-postgresql/pgwatch/v3/api"
 	"github.com/destrex271/pgwatch3_rpc_server/sinks"
+	"github.com/destrex271/pgwatch3_rpc_server/sinks/pb"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // mockHTTPServer creates a mock Pinot controller server for testing
@@ -99,35 +101,21 @@ func setupTestConfigDir(t *testing.T) (string, func()) {
 	return tempDir, cleanup
 }
 
-// getMeasurementEnvelope creates a test measurement envelope
-func getMeasurementEnvelope() *api.MeasurementEnvelope {
-	measurement := make(map[string]any)
-	measurement["cpu"] = "0.001"
-	measurement["checkpointer"] = "1"
-	var measurements []map[string]any
-	measurements = append(measurements, measurement)
-
-	sql := make(map[int]string)
-	sql[12] = "select * from abc;"
-	metrics := &api.Metric{
-		SQLs:        sql,
-		InitSQL:     "select * from abc;",
-		NodeStatus:  "healthy",
-		StorageName: "teststore",
-		Description: "test metric",
+func GetTestMeasurementEnvelope() *pb.MeasurementEnvelope {
+	st, err := structpb.NewStruct(map[string]any{"key": "val"})
+	if err != nil {
+		panic(err)
 	}
-
-	return &api.MeasurementEnvelope{
+	measurements := []*structpb.Struct{st}
+	return &pb.MeasurementEnvelope{
 		DBName:           "test",
-		SourceType:       "test_source",
 		MetricName:       "testMetric",
-		CustomTags:       nil,
+		CustomTags: 	  map[string]string{"tagName": "tagValue"},
 		Data:             measurements,
-		MetricDef:        *metrics,
-		RealDbname:       "test",
-		SystemIdentifier: "Identifier",
 	}
 }
+
+// Tests begin from here
 
 func TestNewPinotReceiver(t *testing.T) {
 	server := mockHTTPServer()
@@ -173,7 +161,7 @@ func TestInitializePinotTable(t *testing.T) {
 	assert.Contains(t, err.Error(), "schema config file not found", "Error should mention missing schema file")
 }
 
-func TestUpdateMeasurements_ValidData(t *testing.T) {
+func TestUpdateMeasurements(t *testing.T) {
 	server := mockHTTPServer()
 	defer server.Close()
 
@@ -181,14 +169,18 @@ func TestUpdateMeasurements_ValidData(t *testing.T) {
 	defer cleanup()
 
 	receiver, err := NewPinotReceiver(server.URL, "pgwatch_metrics", configDir)
-	assert.NoError(t, err, "NewPinotReceiver should initialize without error")
+	assert.NoError(t, err)
 
-	// Test valid measurement update
-	msg := getMeasurementEnvelope()
-	logMsg := new(string)
-	err = receiver.UpdateMeasurements(msg, logMsg)
-	assert.NoError(t, err, "Valid measurement update should succeed")
-	assert.Contains(t, *logMsg, "Successfully inserted batch", "Log message should indicate success")
+	msg := GetTestMeasurementEnvelope()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	_, err = receiver.UpdateMeasurements(ctx, msg)
+	assert.NoError(t, err)
+
+	cancel()
+	reply, err := receiver.UpdateMeasurements(ctx, msg)
+	assert.NoError(t, err)
+	assert.Equal(t, reply.GetLogmsg(), "context cancelled, stopping writer...")
 }
 
 func TestPinotAPIErrors(t *testing.T) {

--- a/cmd/s3_receiver/main.go
+++ b/cmd/s3_receiver/main.go
@@ -21,13 +21,12 @@ func main() {
 		return
 	}
 
-	var server sinks.Receiver
 	server, err := NewS3Receiver(*awsEndpoint, *awsRegion, username, password)
 	if err != nil {
 		log.Fatal("[ERROR]: Unable to create S3 receiver", err)
 	}
 
-	if err := sinks.Listen(server, *port); err != nil {
+	if err := sinks.ListenAndServe(server, *port); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/s3_receiver/s3_receiver_test.go
+++ b/cmd/s3_receiver/s3_receiver_test.go
@@ -3,42 +3,28 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
+	"os"
 	"testing"
 
-	"github.com/cybertec-postgresql/pgwatch/v3/api"
+	"github.com/destrex271/pgwatch3_rpc_server/sinks/pb"
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/assert"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/localstack"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func getMeasurementEnvelope() *api.MeasurementEnvelope {
-	measurement := make(map[string]any)
-	measurement["cpu"] = "0.001"
-	measurement["checkpointer"] = "1"
-	var measurements []map[string]any
-	measurements = append(measurements, measurement)
-
-	sql := make(map[int]string)
-	sql[12] = "select * from abc;"
-	metrics := &api.Metric{
-		SQLs:        sql,
-		InitSQL:     "select * from abc;",
-		NodeStatus:  "healthy",
-		StorageName: "teststore",
-		Description: "test metric",
+func GetTestMeasurementEnvelope() *pb.MeasurementEnvelope {
+	st, err := structpb.NewStruct(map[string]any{"key": "val"})
+	if err != nil {
+		panic(err)
 	}
-
-	return &api.MeasurementEnvelope{
+	measurements := []*structpb.Struct{st}
+	return &pb.MeasurementEnvelope{
 		DBName:           "test",
-		SourceType:       "test_source",
 		MetricName:       "testMetric",
-		CustomTags:       nil,
+		CustomTags: 	  map[string]string{"tagName": "tagValue"},
 		Data:             measurements,
-		MetricDef:        *metrics,
-		RealDbname:       "test",
-		SystemIdentifier: "Identifier",
 	}
 }
 
@@ -51,124 +37,72 @@ func initContainer(ctx context.Context) (*localstack.LocalStackContainer, error)
 	return localstackContainer, err
 }
 
-func TestNewS3Receiver(t *testing.T) {
+var (
+	ctx context.Context
+	mappedPort nat.Port
+	host string
+)
 
-	ctx := context.Background()
+func TestMain(m *testing.M) {
+	ctx = context.Background()
 
 	container, err := initContainer(ctx)
 	if err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
 	defer func() {
-		if err := container.Terminate(ctx); err != nil {
-			log.Println("unable to terminate localstack container : " + err.Error())
-		}
+		_ = container.Terminate(ctx)
 	}()
 
-	mappedPort, err := container.MappedPort(ctx, nat.Port("4566/tcp"))
+	mappedPort, err = container.MappedPort(ctx, nat.Port("4566/tcp"))
 	if err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
 
 	provider, err := testcontainers.NewDockerProvider()
 	if err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
 	defer func() {_ = provider.Close()}()
 
-	host, err := provider.DaemonHost(ctx)
+	host, err = provider.DaemonHost(ctx)
 	if err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
 
-	client, err := NewS3Receiver(fmt.Sprintf("http://%s:%d", host, mappedPort.Int()), "us-east-1", "test", "test")
+	exitCode := m.Run()
+	os.Exit(exitCode)
+}
 
-	assert.Nil(t, err, "error encoutnered while creating S3Receiver")
+var client *S3Receiver
+
+// Tests begin from here
+
+func TestNewS3Receiver(t *testing.T) {
+	var err error
+	client, err = NewS3Receiver(fmt.Sprintf("http://%s:%d", host, mappedPort.Int()), "us-east-1", "test", "test")
+	assert.NoError(t, err, "error encountered while creating S3Receiver")
 	assert.NotNil(t, client, "received nil instead of client")
 }
 
 func TestAddDatabase(t *testing.T) {
-
-	ctx := context.Background()
-
-	container, err := initContainer(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := container.Terminate(ctx); err != nil {
-			log.Println("unable to terminate localstack container : " + err.Error())
-		}
-	}()
-
-	mappedPort, err := container.MappedPort(ctx, nat.Port("4566/tcp"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	provider, err := testcontainers.NewDockerProvider()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {_ = provider.Close()}()
-
-	host, err := provider.DaemonHost(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	client, err := NewS3Receiver(fmt.Sprintf("http://%s:%d", host, mappedPort.Int()), "us-east-1", "test", "test")
-
-	assert.Nil(t, err, "error encoutnered while creating S3Receiver")
-	assert.NotNil(t, client, "received nil instead of client")
-
-	dbname := "test-db"
-	err = client.AddDatabase(dbname)
+	dbname := "test"
+	err := client.AddDatabase(dbname)
 	assert.NoError(t, err)
 
 	res, err := client.DBExists(dbname)
-
-	assert.Nil(t, err, "error encountered while checking bucket")
+	assert.NoError(t, err, "error encountered while checking bucket")
 	assert.True(t, res, "bucket should exist")
 }
 
 func TestUpdateMeasurements(t *testing.T) {
-	ctx := context.Background()
+	msg := GetTestMeasurementEnvelope()
+	_, err := client.UpdateMeasurements(ctx, msg)
+	assert.NoError(t, err, "error encountered while updating measurements")
 
-	container, err := initContainer(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := container.Terminate(ctx); err != nil {
-			log.Println("unable to terminate localstack container : " + err.Error())
-		}
-	}()
-
-	mappedPort, err := container.MappedPort(ctx, nat.Port("4566/tcp"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	provider, err := testcontainers.NewDockerProvider()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {_ = provider.Close()}()
-
-	host, err := provider.DaemonHost(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	client, err := NewS3Receiver(fmt.Sprintf("http://%s:%d", host, mappedPort.Int()), "us-east-1", "test", "test")
-
-	assert.Nil(t, err, "error encoutnered while creating S3Receiver")
-	assert.NotNil(t, client, "received nil instead of client")
-
-	msg := getMeasurementEnvelope()
-	logMsg := new(string)
-	err = client.UpdateMeasurements(msg, logMsg)
-
-	assert.Nil(t, err, "error encountered while updating measurements")
+	newCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	reply, err := client.UpdateMeasurements(newCtx, msg)
+	assert.Equal(t, reply.GetLogmsg(), "context cancelled, stopping writer...")
+	assert.NoError(t, err)
 }

--- a/sinks/common.go
+++ b/sinks/common.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func GetJson[K map[string]string | map[string]any | float64 | api.MeasurementEnvelope | api.Metric | *structpb.Struct](value K) string {
+func GetJson[K map[string]string | map[string]any | float64 | api.MeasurementEnvelope | api.Metric | *structpb.Struct | []*structpb.Struct](value K) string {
 	jsonString, err := json.Marshal(value)
 	if err != nil {
 		log.Default().Fatal("[ERROR]: Unable to parse Metric Definition")

--- a/sinks/common.go
+++ b/sinks/common.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func GetJson[K map[string]string | map[string]any | float64 | api.MeasurementEnvelope | api.Metric | *structpb.Struct | []*structpb.Struct](value K) string {
+func GetJson[K map[string]string | map[string]any | float64 | api.MeasurementEnvelope | api.Metric | *structpb.Struct | []*structpb.Struct | *pb.MeasurementEnvelope](value K) string {
 	jsonString, err := json.Marshal(value)
 	if err != nil {
 		log.Default().Fatal("[ERROR]: Unable to parse Metric Definition")


### PR DESCRIPTION
- migrate `llama` and `kafka` sinks to grpc
- fix llama sink cascaded deleted
- fix kafka sink switched `HandleSyncMetric` operations 
---
this builds on top of #83 review should start from the last 5 commits only