### PR TITLE
[*] Fix `GetJson()` fatally closing on error

### DIFF
--- a/cmd/clickhouse_receiver/clickhouse_receiver.go
+++ b/cmd/clickhouse_receiver/clickhouse_receiver.go
@@ -94,7 +94,10 @@ func (r *ClickHouseReceiver) InsertMeasurements(ctx context.Context, data *pb.Me
 	}
 
 	for _, measurement := range data.GetData() {
-		measurementJson := sinks.GetJson(measurement)
+		measurementJson, err := sinks.GetJson(measurement)
+		if err != nil {
+			continue
+		}
 
 		err = batch.Append(
 			data.GetDBName(), 

--- a/cmd/clickhouse_receiver/clickhouse_receiver_test.go
+++ b/cmd/clickhouse_receiver/clickhouse_receiver_test.go
@@ -101,7 +101,7 @@ func TestClickHouseReceiver(t *testing.T) {
 			var dbname, metric_name, data string
 			tags := make(map[string]string)
 			var timestamp time.Time
-			dataJson := sinks.GetJson(msg.GetData()[0])
+			dataJson, _ := sinks.GetJson(msg.GetData()[0])
 
 			err := rows.Scan(&dbname, &metric_name, &tags, &data, &timestamp)
 			assert.NoError(t, err, "Failed to scan row")

--- a/cmd/csv_receiver/csv_receiver.go
+++ b/cmd/csv_receiver/csv_receiver.go
@@ -51,11 +51,15 @@ func (r CSVReceiver) UpdateMeasurements(ctx context.Context, msg *pb.Measurement
 
 	writer := csv.NewWriter(file)
 
-	customTagsJSON := sinks.GetJson(msg.GetCustomTags())
+	customTagsJSON, _ := sinks.GetJson(msg.GetCustomTags())
 	for _, measurement := range msg.GetData() {
+		measurementJson, err := sinks.GetJson(measurement)
+		if err != nil {
+			continue
+		}
 		record := []string{
 			msg.GetMetricName(),
-			sinks.GetJson(measurement),
+			measurementJson,
 			customTagsJSON,
 		}
 

--- a/cmd/duckdb_receiver/duckdb_receiver.go
+++ b/cmd/duckdb_receiver/duckdb_receiver.go
@@ -81,10 +81,14 @@ func (r *DuckDBReceiver) InsertMeasurements(ctx context.Context, data *pb.Measur
 	defer func() {_ = stmt.Close()}()
 
 	for _, measurement := range data.GetData() {
+		measurementJson, err := sinks.GetJson(measurement)
+		if err != nil {
+			continue
+		}
 		_, err = stmt.Exec(
 			data.GetDBName(),
 			data.GetMetricName(),
-			sinks.GetJson(measurement),
+			measurementJson,
 			customTagsJSON,
 			time.Now(),
 		)

--- a/cmd/duckdb_receiver/duckdb_receiver_test.go
+++ b/cmd/duckdb_receiver/duckdb_receiver_test.go
@@ -92,13 +92,14 @@ func TestUpdateMeasurements(t *testing.T) {
 			err := rows.Scan(&dbname, &metricName, &data, &customTags)
 			assert.NoError(t, err, "Failed to scan row")
 
-			customTagsJSON := sinks.GetJson(msg.GetCustomTags())
-			measurement := sinks.GetJson(msg.GetData()[0])
+			customTagsJSON, _ := sinks.GetJson(msg.GetCustomTags())
+			measurementJson, _ := sinks.GetJson(msg.GetData()[0])
+			dataJson, _ := sinks.GetJson(data)
 
 			assert.Equal(t, msg.GetDBName(), dbname)
 			assert.Equal(t, msg.GetMetricName(), metricName)
 			assert.Equal(t, customTagsJSON, customTags)
-			assert.Equal(t, measurement, sinks.GetJson(data))
+			assert.Equal(t, measurementJson, dataJson)
 
 			rowCount++
 		}

--- a/cmd/kafka_prod_receiver/kafka_prod_receiver_test.go
+++ b/cmd/kafka_prod_receiver/kafka_prod_receiver_test.go
@@ -73,7 +73,7 @@ func TestKafka_UpdateMeasurements(t *testing.T) {
 	_, err = io.Copy(buf, reader)
 	assert.NoError(t, err)
 
-	msg_as_str := sinks.GetJson(msg)
+	msg_as_str, _ := sinks.GetJson(msg)
 	assert.True(t, strings.Contains(buf.String(), msg_as_str), "Unable to retrieve measurements from topic")
 }
 

--- a/cmd/llama_receiver/llama_receiver.go
+++ b/cmd/llama_receiver/llama_receiver.go
@@ -197,7 +197,11 @@ func (r *LLamaReceiver) AddMeasurements(msg *pb.MeasurementEnvelope) error {
 	}
 
 	// insert measurements with current timestamp(default) into table measurements
-	jsonData := sinks.GetJson(msg.GetData())
+	jsonData, err := sinks.GetJson(msg.GetData())
+	if err != nil {
+		return err
+	}
+
 	_, err = conn.Exec(r.Ctx, `INSERT INTO measurements(data, database_id, metric_name) VALUES($1, $2, $3)`, jsonData, id, msg.GetMetricName())
 	if err != nil {
 		return err

--- a/cmd/parquet_receiver/parquet_receiver.go
+++ b/cmd/parquet_receiver/parquet_receiver.go
@@ -48,10 +48,16 @@ func (r ParquetReceiver) UpdateMeasurements(ctx context.Context, msg *pb.Measure
 	data := ParquetSchema{}
 	data.DBName = msg.GetDBName()
 	data.MetricName = msg.GetMetricName()
-	data.Tags = sinks.GetJson(msg.CustomTags)
+	data.Tags, err = sinks.GetJson(msg.CustomTags)
+	if err != nil {
+		return nil, err
+	}
 
 	for _, measurement := range msg.GetData() {
-		data.Data = sinks.GetJson(measurement)
+		data.Data, err = sinks.GetJson(measurement)
+		if err != nil {
+			continue
+		}
 		data_points = append(data_points, data)
 	}
 

--- a/cmd/text_receiver/text_receiver.go
+++ b/cmd/text_receiver/text_receiver.go
@@ -42,7 +42,11 @@ func (r TextReceiver) UpdateMeasurements(ctx context.Context, msg *pb.Measuremen
 	output := "DBName: " + msg.GetDBName() + "\n" + "Metric: " + msg.GetMetricName() + "\n"
 
 	for _, measurement := range msg.GetData() {
-		output += sinks.GetJson(measurement) + "\n"
+		data, err := sinks.GetJson(measurement)
+		if err != nil {
+			continue
+		}
+		output += data + "\n"
 	}
 
 	output += "\n===================================\n"

--- a/sinks/common.go
+++ b/sinks/common.go
@@ -2,20 +2,18 @@ package sinks
 
 import (
 	"encoding/json"
-	"log"
 
 	"github.com/destrex271/pgwatch3_rpc_server/sinks/pb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func GetJson[K map[string]string | map[string]any | float64 | *structpb.Struct | []*structpb.Struct | *pb.MeasurementEnvelope](value K) string {
+func GetJson(value any) (string, error) {
 	jsonString, err := json.Marshal(value)
 	if err != nil {
-		log.Default().Fatal("[ERROR]: Unable to parse Metric Definition")
+		return "", err
 	}
-	return string(jsonString)
+	return string(jsonString), nil
 }
 
 func IsValidMeasurement(msg *pb.MeasurementEnvelope) error {


### PR DESCRIPTION
- update `GetJson()` to return error instead of using `log.Fatal()`
- update sinks to receive 2 returns from `GetJson()`